### PR TITLE
create_session with user mode

### DIFF
--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -409,8 +409,8 @@ class Session:
 
         return True if _send_server_request() else False
 
-    def __copy__(self):
-        session = super().__new__(type(self))
+    def __copy__(self) -> "Session":
+        session = super().__new__(Session)
         session.__dict__.update(self.__dict__)
         return session
 

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -529,7 +529,7 @@ class TenantSession(Session):
         port: int,
         tenant_username: str,
         tenant_password: str,
-        timeout: int = 0,
+        timeout: int = 30,
     ) -> None:
         super().__init__(url, port, tenant_username, tenant_password, timeout)
 

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -469,13 +469,13 @@ class ProviderAsTenantSession(Session):
         self.subdomain = subdomain
         super().__init__(url, port, username, password, timeout)
 
-    def __get_tenant_id(self, subdomain: str) -> str:
+    def __get_tenant_id(self) -> str:
         """Gets tenant UUID for tenant subdomain.
         Returns:
             tenant UUID
         """
         tenants = self.get_data('/dataservice/tenant')
-        tenant_ids = [tenant.get('tenantId') for tenant in tenants if tenant['subDomain'] == subdomain]
+        tenant_ids = [tenant.get('tenantId') for tenant in tenants if tenant['subDomain'] == self.subdomain]
         assert len(tenant_ids) > 0, f"Tenant not found for subdomain: {self.subdomain}"
         return tenant_ids[0]
 
@@ -490,9 +490,11 @@ class ProviderAsTenantSession(Session):
         assert 'VSessionId' in response, "Invalid vsessionid response"
         return response['VSessionId']
 
-    def __switch_to_tenant(self, subdomain: str) -> None:
+    def __switch_to_tenant(self, subdomain: str = None) -> None:
         """As provider impersonate tenant session."""
-        tenant_id = self.__get_tenant_id(subdomain)
+        if subdomain:
+            self.subdomain = subdomain
+        tenant_id = self.__get_tenant_id()
         vsession_id = self.__create_vsession(tenant_id)
         assert vsession_id != '', 'Switch to tenant expecting VSessionId to not be empty'
         self.session_headers['VSessionId'] = vsession_id

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -469,6 +469,11 @@ class ProviderAsTenantSession(Session):
         self.subdomain = subdomain
         super().__init__(url, port, username, password, timeout)
 
+    def login(self) -> None:
+        """Logs in to vManage API as Provider using username/password and switches to Tenant."""
+        super().login()
+        self.__switch_to_tenant()
+
     def __get_tenant_id(self) -> str:
         """Gets tenant UUID for tenant subdomain.
         Returns:

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -62,8 +62,8 @@ def create_session(
 
     session = Session(url, port, username, password, subdomain, timeout)
     response = cast(dict, session.server())
-    user_mode = response["userMode"]
-    view_mode = response["viewMode"]
+    user_mode = response.get("userMode", UserMode.NOT_DEFINED)
+    view_mode = response.get("viewMode", ViewMode.NOT_DEFINED)
 
     if user_mode == UserMode.TENANT.value and not subdomain and view_mode == UserMode.TENANT.value:
         session.session_type = SessionType.TENANT

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -72,7 +72,7 @@ def create_session(
     elif user_mode == UserMode.PROVIDER.value and view_mode == UserMode.TENANT.value:
         session.session_type = SessionType.PROVIDER_AS_TENANT
     elif user_mode == UserMode.TENANT.value and subdomain:
-        raise SessionNotCreatedError("Session not created. 'subdomain' passed to tenant session, "
+        raise SessionNotCreatedError(f"Session not created. Subdomain {subdomain} passed to tenant session, "
                                      "cannot switch to tenant from tenant user mode.")
     else:
         raise SessionNotCreatedError("Session not created. Unrecognized user mode.")

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -31,6 +31,13 @@ class SessionType(Enum):
 class UserMode(Enum):
     PROVIDER = "provider"
     TENANT = "tenant"
+    NOT_DEFINED = None
+
+
+class ViewMode(Enum):
+    PROVIDER = "provider"
+    TENANT = "tenant"
+    NOT_DEFINED = None
 
 
 class SessionNotCreatedError(Exception):
@@ -62,16 +69,16 @@ def create_session(
 
     session = Session(url, port, username, password, subdomain, timeout)
     response = cast(dict, session.server())
-    user_mode = response.get("userMode", UserMode.NOT_DEFINED)
-    view_mode = response.get("viewMode", ViewMode.NOT_DEFINED)
+    user_mode = UserMode(response.get("userMode"))
+    view_mode = ViewMode(response.get("viewMode"))
 
-    if user_mode == UserMode.TENANT.value and not subdomain and view_mode == UserMode.TENANT.value:
+    if user_mode == UserMode.TENANT and not subdomain and view_mode == ViewMode.TENANT:
         session.session_type = SessionType.TENANT
-    elif user_mode == UserMode.PROVIDER.value and not subdomain and view_mode == UserMode.PROVIDER.value:
+    elif user_mode == UserMode.PROVIDER and not subdomain and view_mode == ViewMode.PROVIDER:
         session.session_type = SessionType.PROVIDER
-    elif user_mode == UserMode.PROVIDER.value and view_mode == UserMode.TENANT.value:
+    elif user_mode == UserMode.PROVIDER and view_mode == ViewMode.TENANT:
         session.session_type = SessionType.PROVIDER_AS_TENANT
-    elif user_mode == UserMode.TENANT.value and subdomain:
+    elif user_mode == UserMode.TENANT and subdomain:
         raise SessionNotCreatedError(f"Session not created. Subdomain {subdomain} passed to tenant session, "
                                      "cannot switch to tenant from tenant user mode.")
     else:

--- a/vmngclient/utils/user_mode.py
+++ b/vmngclient/utils/user_mode.py
@@ -1,6 +1,0 @@
-from enum import Enum
-
-
-class UserMode(Enum):
-    provider = 'provider'
-    tenant = 'tenant'

--- a/vmngclient/utils/user_mode.py
+++ b/vmngclient/utils/user_mode.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class UserMode(Enum):
+    provider = 'provider'
+    tenant = 'tenant'


### PR DESCRIPTION
Using 3 classes `TenantSession`, `ProviderAsTenantSession` and `ProviderSession`, all inherit from Session. End user uses only `create_session`.

Factory function checks user mode. To create session just pass `url`, `port`, `username`, `password` and optional `subdomain` (used just to specify to which tenant to switch while creating `ProviderAsTenantSession`).

```python
tenant_session = create_session(sub_domain_1, port, username_tenant, password)
print(type(tenant_session))
# <class 'vmngclient.session.TenantSession'>

provider_session = create_session(domain, port, username_provider, password)
print(type(provider_session))
# <class 'vmngclient.session.ProviderSession'>

provider_as_tenant_session = create_session(domain, port, username_provider, password, subdomain=subdomain)
print(type(provider_as_tenant_session))
# <class 'vmngclient.session.ProviderAsTenantSession'>

tenant_session = create_session(sub_domain_1, port, username_tenant, password, subdomain=sub_domain_2)
# vmngclient.session.SessionNotCreatedError: Session not created. 'subdomain' passed to tenant session, cannot switch to tenant from tenant user mode.
```

This solution works both with domain name and IP address.
