### PR TITLE
Admintech Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ except UserAlreadyExistsError as error:
 ```
 </details>
 
+## API usage examples
+
+### AdminTechAPI
+
+<details>
+    <summary>Python (click to expand)</summary>
+
+```Python
+from vmngclient.session import create_vManageSession
+from vmngclient.api.admin_tech_api import AdminTechAPI
+
+session = create_vManageSession(url=..., username=..., password=...)
+admintech = AdminTechAPI(session)
+filename = admintech.generate("172.16.255.11")
+admintech.download(filename)
+admintech.delete(filename)
+```
+
+</details>
+
 
 ## Contributing, reporting issues, seeking support
 Please contact authors direcly or via Issues Github page.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vmngclient"
-version = "0.1.2"
+version = "0.2.0"
 description = "Universal vManage API"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"

--- a/vmngclient/api/admin_tech_api.py
+++ b/vmngclient/api/admin_tech_api.py
@@ -18,6 +18,10 @@ class GenerateAdminTechLogError(Exception):
     pass
 
 
+class DownloadAdminTechLogError(Exception):
+    pass
+
+
 class RequestTokenIdNotFound(Exception):
     pass
 
@@ -35,17 +39,17 @@ class AdminTechAPI:
     def __str__(self) -> str:
         return str(self.session)
 
-    def get(self, device_id: str) -> AdminTech:
+    def get(self, device_id: str) -> List[AdminTech]:
         """Gets admintech log information for a device.
 
         Args:
             device_id: device ID (usually system-ip)
         Returns:
-            AdminTech object for given device
+            AdminTech object list for given device
         """
-        body = {'deviceIP': device_id}
-        response = self.session.post(url='/dataservice/device/tools/admintechlist', data=body).json()
-        return create_dataclass(AdminTech, response[0])
+        body = {"deviceIP": device_id}
+        response = self.session.post(url="/dataservice/device/tools/admintechlist", data=body).json()
+        return [create_dataclass(AdminTech, data) for data in response]
 
     def get_all(self) -> List[AdminTech]:
         """Gets admintech log information for all devices.
@@ -53,72 +57,92 @@ class AdminTechAPI:
         Returns:
             AdminTech objects list for all devices
         """
-        response = self.session.get_data('/dataservice/device/tools/admintechs')
-        return [create_dataclass(AdminTech, dev_data) for dev_data in response]
+        response = self.session.get_data("/dataservice/device/tools/admintechs")
+        return [create_dataclass(AdminTech, data) for data in response]
 
     def generate(
-        self, device_id: str, request_timeout: int = 3600, polling_timeout: int = 1200, polling_interval: int = 30
+        self,
+        device_id: str,
+        exclude_cores: bool = True,
+        exclude_tech: bool = False,
+        exclude_logs: bool = True,
+        request_timeout: int = 3600,
+        polling_timeout: int = 1200,
+        polling_interval: int = 30,
     ) -> str:
         """Generates admintech log for a device.
 
         Args:
             device_id: device ID (usually system-ip)
-            request_timeout: wait time in seconds to generate admin tech after request
+            exclude_cores: exclude core in generated admintech log file
+            exclude_tech: exclude core in generated admintech log file
+            exclude_logs: exclude core in generated admintech log file
+            request_timeout: wait time in seconds to generate admintech after request
             polling_timeout: retry period in seconds for successfull request
             polling_interval: polling interval in seconds between request attempts
         Returns:
             filename of generated admintech log
         """
-        create_admin_tech_error_msgs = 'Admin tech creation already in progress'
-        body = {'deviceIP': device_id, 'exclude-cores': True, 'exclude-tech': False, 'exclude-logs': True}
+        create_admin_tech_error_msgs = "Admin tech creation already in progress"
+        body = {
+            "deviceIP": device_id,
+            "exclude-cores": exclude_cores,
+            "exclude-tech": exclude_tech,
+            "exclude-logs": exclude_logs,
+        }
         polling_timer = polling_timeout
         while polling_timer > 0:
             try:
-                response = self.session.post(url='/dataservice/device/tools/admintech', data=body)
+                self.session.timeout = request_timeout
+                response = self.session.post_json('/dataservice/device/tools/admintech', body)
                 return cast(dict, response)['fileName']
             except HTTPError as error:
                 error_details = error.read().decode()
-                if error.code != 400 and create_admin_tech_error_msgs not in json.loads(error_details).get('error').get(
-                    'details'
+                if error.code != 400 and create_admin_tech_error_msgs not in json.loads(error_details).get("error").get(
+                    "details"
                 ):
-                    raise GenerateAdminTechLogError(f'It is not possible to generate admintech log for {device_id}')
+                    raise GenerateAdminTechLogError(f"It is not possible to generate admintech log for {device_id}")
                 time.sleep(polling_interval)
                 polling_timer -= polling_interval
+            finally:
+                self.session.timeout = _session_timeout
         raise GenerateAdminTechLogError(f'It is not possible to generate admintech log for {device_id}')
 
-    def _get_token_id(self, device_id) -> str:
-        admin_tech_filename = self.generate(device_id)
+    def _get_token_id(self, filename: str) -> str:
         admin_techs = self.get_all()
         for admin_tech in admin_techs:
-            if admin_tech_filename == admin_tech.filename:
+            if filename == admin_tech.filename:
                 return admin_tech.token_id
-        raise RequestTokenIdNotFound(f'Request Id of admin tech generation request not found for device: {device_id}')
+        raise RequestTokenIdNotFound(
+            f"requestTokenId of admin tech generation request not found for file name: {filename}"
+        )
 
-    def delete(self, device_id: str) -> Response:
+    def delete(self, filename: str) -> Response:
         """Deletes admin tech logs for a device.
 
         Args:
-            device_id: device ID (usually system-ip)
+            filename: name of admin_tech file
         Returns:
             response: http response for delete operation
         """
 
-        token_id = self._get_token_id(device_id)
-        response = self.session.delete(f'/dataservice/device/tools/admintech/{token_id}')
+        token_id = self._get_token_id(filename)
+        response = self.session.delete(f"/dataservice/device/tools/admintech/{token_id}")
         return response
 
-    def download(self, admin_tech_name: str, download_dir: Optional[Path] = None) -> Path:
+    def download(self, filename: str, download_dir: Optional[Path] = None) -> Path:
         """Downloads admintech log for a device.
 
         Args:
-            admin_tech_name: name of admin_tech file
+            filename: name of admin_tech file
             download_dir: download directory (defaults to current working directory)
         Returns:
             path to downloaded admin_tech file
         """
         if not download_dir:
             download_dir = Path.cwd()
-        download_path = download_dir / admin_tech_name
-        url = f'/dataservice/device/tools/admintech/download/{admin_tech_name}'
-        self.session.get_file(url, download_path)
+        download_path = download_dir / filename
+        url = f"/dataservice/device/tools/admintech/download/{filename}"
+        if self.session.get_file(url=url, filename=download_path).status_code != 200:
+            raise GenerateAdminTechLogError(f"Cannot download admin tech file: {filename} from remote")
         return download_path

--- a/vmngclient/api/admin_tech_api.py
+++ b/vmngclient/api/admin_tech_api.py
@@ -106,11 +106,12 @@ class AdminTechAPI:
                 response = http_error.response
             if response.status_code == 200:
                 return response.json()["fileName"]
-            if response.status_code != 400 and create_admin_tech_error_msgs not in response.json().get("error", {}).get(
+            if response.status_code == 400 and create_admin_tech_error_msgs in response.json().get("error", {}).get(
                 "details", ""
             ):
+                logger.warning(f"Admin tech creation already in progress, retrying in {polling_interval} seconds")
+            else:
                 raise GenerateAdminTechLogError(f"It is not possible to generate admintech log for {device_id}")
-            logger.warning(f"Admin tech creation already in progress, retrying in {polling_interval} seconds")
             time.sleep(polling_interval)
             polling_timer -= polling_interval
         raise GenerateAdminTechLogError(f'It is not possible to generate admintech log for {device_id}')

--- a/vmngclient/dataclasses.py
+++ b/vmngclient/dataclasses.py
@@ -20,11 +20,23 @@ class DataclassBase:
 
 @define(frozen=True, field_transformer=convert_attributes)
 class AdminTech(DataclassBase):
-    state: str
+    creation_time: dt.datetime = field(metadata={FIELD_NAME: "creationTime"})
+    size: int
     filename: str = field(metadata={FIELD_NAME: "fileName"})
-    token_id: str = field(metadata={FIELD_NAME: "requestTokenId"})
+    state: str
+    tac_state: Optional[str]
     device_ip: str = field(metadata={FIELD_NAME: "deviceIP"})
     system_ip: str = field(metadata={FIELD_NAME: "local-system-ip"})
+    token_id: str = field(metadata={FIELD_NAME: "requestTokenId"})
+
+
+@define(frozen=True, field_transformer=convert_attributes)
+class DeviceAdminTech(DataclassBase):
+    filename: str = field(metadata={FIELD_NAME: "fileName"})
+    creation_time: dt.datetime = field(metadata={FIELD_NAME: "creationTime"})
+    size: int
+    state: str
+    token_id: Optional[str] = field(default=None, metadata={FIELD_NAME: "requestTokenId"})
 
 
 @define(frozen=True, field_transformer=convert_attributes)

--- a/vmngclient/tests/test_admin_tech_api.py
+++ b/vmngclient/tests/test_admin_tech_api.py
@@ -1,0 +1,185 @@
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import ANY, patch
+
+from vmngclient.api.admin_tech_api import (
+    AdminTechAPI,
+    DownloadAdminTechLogError,
+    GenerateAdminTechLogError,
+    RequestTokenIdNotFound,
+)
+from vmngclient.dataclasses import DeviceAdminTech
+
+
+class TestAdminTechAPI(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+        self.device_ip = "169.254.10.4"
+        self.admin_tech_generate_response = {
+            "size": 1479740,
+            "fileName": "172.16.253.129-vm129-20221116-065219-admin-tech.tar.gz",
+        }
+        self.device_admin_tech_infos = {
+            "data": [
+                {
+                    "fileName": "172.16.255.200-vm200-20221116-060922-admin-tech.tar.gz",
+                    "creationTime": 1668578961380,
+                    "size": 31934859,
+                    "state": "done",
+                    "requestTokenId": "null",
+                }
+            ]
+        }
+        self.admin_tech_infos = {
+            "data": [
+                {
+                    "creationTime": 1668581537503,
+                    "size": self.admin_tech_generate_response["size"],
+                    "fileName": self.admin_tech_generate_response["fileName"],
+                    "state": "done",
+                    "tac_state": "notStarted",
+                    "deviceIP": self.device_ip,
+                    "local-system-ip": "172.16.253.129",
+                    "requestTokenId": "aace1605-ba9a-40fa-990b-c694a011a866",
+                },
+                {
+                    "creationTime": 1668578961380,
+                    "size": 31934859,
+                    "fileName": "172.16.255.200-vm200-20221116-060922-admin-tech.tar.gz",
+                    "state": "done",
+                    "tac_state": "notStarted",
+                    "deviceIP": "169.254.10.1",
+                    "local-system-ip": "172.16.255.200",
+                    "requestTokenId": "8b7f9a3a-e137-4af4-b2f9-b04808e1e2eb",
+                },
+            ]
+        }
+        self.admin_tech_info = self.admin_tech_infos["data"][0]
+        self.download_file_content = "Downloaded file content"
+        self.download_file = io.BytesIO(self.download_file_content.encode())
+
+    @patch("vmngclient.session.vManageSession")
+    @patch("requests.Response")
+    def test_get(self, mock_session, mock_response):
+        # Arrange
+        mock_session.post.return_value = mock_response
+        mock_response.json.return_value = self.device_admin_tech_infos
+        # Act
+        admintechs = AdminTechAPI(mock_session).get(self.device_ip)
+        # Assert
+        mock_session.post.assert_called_once_with(
+            url="/dataservice/device/tools/admintechlist", json={"deviceIP": self.device_ip}
+        )
+        self.assertIsInstance(admintechs[0], DeviceAdminTech)
+
+    @patch("vmngclient.session.vManageSession")
+    @patch("requests.Response")
+    def test_get_all(self, mock_session, mock_response):
+        # Arrange
+        mock_session.get.return_value = mock_response
+        mock_response.json.return_value = self.admin_tech_infos
+        # Act
+        admintechs = AdminTechAPI(mock_session).get_all()
+        # Assert
+        mock_session.get.assert_called_once_with("/dataservice/device/tools/admintechs")
+        self.assertEqual(len(admintechs), len(self.admin_tech_infos["data"]))
+
+    @patch("vmngclient.session.vManageSession")
+    @patch("requests.Response")
+    def test_generate(self, mock_session, mock_response):
+        # Arrange
+        mock_session.post.return_value = mock_response
+        mock_response.status_code = 200
+        mock_response.json.return_value = self.admin_tech_generate_response
+        # Act
+        filename = AdminTechAPI(mock_session).generate(
+            device_id=self.device_ip, polling_timeout=0.01, polling_interval=0.01
+        )
+        print(filename)
+        # Assert
+        mock_session.post.assert_called_once_with(url="/dataservice/device/tools/admintech", json=ANY, timeout=ANY)
+        self.assertEqual(filename, self.admin_tech_generate_response["fileName"])
+
+    @patch("vmngclient.session.vManageSession")
+    @patch("requests.Response")
+    def test_generate_in_progress_error_retry(self, mock_session, mock_response):
+        # Arrange
+        mock_session.post.return_value = mock_response
+        mock_response.status_code = 400
+        mock_response.json.return_value = {"error": {"details": "Admin tech creation already in progress"}}
+        interval = 0.01
+        count = 2
+        # Act/Assert
+        with self.assertRaises(GenerateAdminTechLogError):
+            AdminTechAPI(mock_session).generate(
+                device_id=self.device_ip, polling_timeout=interval * count, polling_interval=interval
+            )
+        self.assertEqual(mock_session.post.call_count, count)
+
+    @patch("vmngclient.session.vManageSession")
+    @patch("requests.Response")
+    def test_generate_error(self, mock_session, mock_response):
+        # Arrange
+        mock_session.post.return_value = mock_response
+        mock_response.status_code = 500
+        mock_response.json.return_value = {"error": {"details": "Server Error"}}
+        interval = 0.01
+        count = 3
+        # Act/Assert
+        with self.assertRaises(GenerateAdminTechLogError):
+            AdminTechAPI(mock_session).generate(
+                device_id=self.device_ip, polling_timeout=interval * count, polling_interval=interval
+            )
+        mock_session.post.assert_called_once()
+
+    @patch("vmngclient.session.vManageSession")
+    @patch("requests.Response")
+    def test_delete(self, mock_session, mock_response):
+        # Arrange
+        filename = self.admin_tech_generate_response["fileName"]
+        token_id = self.admin_tech_info["requestTokenId"]
+        mock_session.get.return_value = mock_response
+        mock_response.json.return_value = self.admin_tech_infos
+        # Act
+        AdminTechAPI(mock_session).delete(filename)
+        # Assert
+        mock_session.delete.assert_called_once_with(f"/dataservice/device/tools/admintech/{token_id}")
+
+    @patch("vmngclient.session.vManageSession")
+    @patch("requests.Response")
+    def test_delete_token_not_found(self, mock_session, mock_response):
+        # Arrange
+        mock_session.get.return_value = mock_response
+        mock_response.json.return_value = self.admin_tech_infos
+        # Act/Assert
+        with self.assertRaises(RequestTokenIdNotFound):
+            AdminTechAPI(mock_session).delete("fake-filename.tar.gz")
+
+    @patch("vmngclient.session.vManageSession")
+    @patch("requests.Response")
+    def test_download(self, mock_session, mock_response):
+        # Arrange
+        filename = self.admin_tech_generate_response["fileName"]
+        mock_session.get_file.return_value = mock_response
+        mock_session.get.return_value = mock_response
+        mock_response.status_code = 200
+        mock_response.content = self.download_file_content
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Act
+            download_path = AdminTechAPI(mock_session).download(filename, Path(tmpdir))
+            # Assert
+            self.assertEqual(download_path, Path(tmpdir) / filename)
+
+    @patch("vmngclient.session.vManageSession")
+    @patch("requests.Response")
+    def test_download_error(self, mock_session, mock_response):
+        # Arrange
+        mock_session.get.return_value = mock_response
+        mock_response.status_code = 500
+        mock_response.json.return_value = {"error": {"details": "Server Error"}}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Act/Assert
+            with self.assertRaises(DownloadAdminTechLogError):
+                AdminTechAPI(mock_session).download("fake-filename.tar.gz", Path(tmpdir))

--- a/vmngclient/utils/response.py
+++ b/vmngclient/utils/response.py
@@ -31,8 +31,12 @@ def response_debug(response: Response, headers: bool = False) -> str:
         request_body = str(request_body, encoding="utf-8")
     info = VManageResponseDebugInfo(
         request={"method": response.request.method, "url": response.request.url, "body": request_body},
-        response={"status": response.status_code, "reason": response.reason, "text": response.text},
+        response={"status": response.status_code, "reason": response.reason},
     )
+    if len(response.text) <= 1024:
+        info.response.update({"text": response.text})
+    else:
+        info.response.update({"text(trimmed)": response.text[:128]})
     if headers:
         info.request.update({"headers": dict(response.request.headers.items())})
         info.response.update({"headers": dict(response.headers.items())})


### PR DESCRIPTION
- migrated to requests lib
- added optional generate content options (Cores, Techs, Logs)
- delete no longer automatically generates fresh admintech
- added unit tests
- added API usage example in README.md


basic usage remains similar:


```python
session = create_vManageSession(url="127.0.0.1", port=443, username="admin", password="admin")
admintech = AdminTechAPI(session)
filename = admintech.generate(device_id="172.16.255.11")
admintech.download(filename)
admintech.delete(filename)
```

- added logging
```text
2022-12-08 13:04:58,710 - vmngclient.session - INFO - Logged as admin. The session type is SessionType.TENANT
2022-12-08 13:04:58,710 - vmngclient.api.admin_tech_api - INFO - Starting AdminTech log creation for 172.16.255.11, waiting up to 3600 seconds to complete
2022-12-08 13:10:04,777 - vmngclient.api.admin_tech_api - INFO - Downloaded AdminTech file to: /Users/sbasan/repos/vManage-client/172.16.255.11-vm1-20221208-120459-admin-tech.tar.gz
2022-12-08 13:10:05,313 - vmngclient.api.admin_tech_api - INFO - Deleted AdminTech file 172.16.255.11-vm1-20221208-120459-admin-tech.tar.gz on remote
```