### PR TITLE
Port as option

### DIFF
--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -68,7 +68,7 @@ def create_session(
     Returns:
         Session object
     """
-    session = Session(url, port, username, password, subdomain, timeout)
+    session = Session(url, username, password, port, subdomain, timeout)
     response = cast(dict, session.server())
 
     try:
@@ -115,9 +115,9 @@ class Session:
 
     def __init__(
         self, url: str,
-        port: int,
         username: str,
         password: str,
+        port: int = None,
         subdomain: str = None,
         timeout: int = 30
     ):
@@ -387,7 +387,7 @@ class Session:
         ctx.verify_mode = ssl.CERT_NONE
         return ctx
 
-    def __create_base_url(self, url: str, port: int) -> str:
+    def __create_base_url(self, url: str, port: int = None) -> str:
         """Creates base url based on ip address and port.
 
         Args:

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -116,7 +116,7 @@ class Session:
         self, url: str,
         username: str,
         password: str,
-        port: int = None,
+        port: Optional[int],
         subdomain: str = None,
         timeout: int = 30
     ):
@@ -386,7 +386,7 @@ class Session:
         ctx.verify_mode = ssl.CERT_NONE
         return ctx
 
-    def __create_base_url(self, url: str, port: int = None) -> str:
+    def __create_base_url(self, url: str, port: Optional[int]) -> str:
         """Creates base url based on ip address and port.
 
         Args:

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -7,7 +7,6 @@ import time
 from enum import Enum, auto
 from http import HTTPStatus
 from http.client import HTTPException, HTTPResponse
-from ipaddress import AddressValueError, IPv4Address
 from json import dumps, loads
 from typing import Any, Dict, List, Optional, Union, cast
 from urllib.error import HTTPError

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -48,9 +48,9 @@ class SessionNotCreatedError(Exception):
 
 def create_session(
     url: str,
-    port: int,
     username: str,
     password: str,
+    port: int = None,
     subdomain: str = None,
     timeout: int = 30,
 ) -> Session:
@@ -397,11 +397,9 @@ class Session:
         Returns:
             str: Base url shared for every request.
         """
-        try:
-            IPv4Address(url)
-        except (AddressValueError, AttributeError) as error_info:
-            logger.info(f"Please provide correct IPv4 address. Error info: {error_info}")
-        return f"https://{url}:{port}"
+        if port:
+            return f"https://{url}:{port}"
+        return f"https://{url}"
 
     def about(self) -> Union[List[Any], Dict[Any, Any]]:
         response = self.get_data(url="/dataservice/client/about")

--- a/vmngclient/tests/test_session.py
+++ b/vmngclient/tests/test_session.py
@@ -6,6 +6,6 @@ from vmngclient.session import Session
 class TestSessionConstructor(unittest.TestCase):
     def test_session_str(self):
         # Arrange, Act
-        session = Session("1.1.1.1", 111, "admin", None)
+        session = Session("1.1.1.1", "admin", None, port=111)
         # Assert
         self.assertEqual(str(session), "admin@https://1.1.1.1:111")


### PR DESCRIPTION
Now, user have to use port as an argument while creating session in vmngclient. Some vmanages can have domains without clearly defined port in them. Users should not have to enter developer tools to check for the port they are using. Instead, they should be able to just enter the domain and their credentials to create a session object.

```python
# old implementation
session = create_session("domain.com", 1111, "user", "password")

# new implementation
# if port not needed
session = create_session("domain.com", "user", "password")
# if port needed
session = create_session("domain.com", "user", "password", port=1111)
```