### PR TITLE
Logging change

### DIFF
--- a/vmngclient/__init__.py
+++ b/vmngclient/__init__.py
@@ -5,4 +5,7 @@ from typing import Final
 
 LOGGING_CONF_DIR: Final[str] = str(Path(__file__).parents[0] / 'logging.conf')
 
-logging.config.fileConfig(LOGGING_CONF_DIR, disable_existing_loggers=False)
+vmngclient_logger = logging.getLogger("vmngclient")
+
+if not vmngclient_logger.handlers:
+    logging.config.fileConfig(LOGGING_CONF_DIR, disable_existing_loggers=False)

--- a/vmngclient/__init__.py
+++ b/vmngclient/__init__.py
@@ -5,7 +5,7 @@ from typing import Final
 
 LOGGING_CONF_DIR: Final[str] = str(Path(__file__).parents[0] / 'logging.conf')
 
-vmngclient_logger = logging.getLogger("vmngclient")
+vmngclient_logger = logging.getLogger(__name__)
 
 if not vmngclient_logger.handlers:
     logging.config.fileConfig(LOGGING_CONF_DIR, disable_existing_loggers=False)

--- a/vmngclient/logging.conf
+++ b/vmngclient/logging.conf
@@ -27,7 +27,7 @@ args=(sys.stdout,)
 class=FileHandler
 level=DEBUG
 formatter=simpleFormatter
-args=('test.log', 'w')
+args=('vmngclient.log', 'w')
 
 [formatter_simpleFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s


### PR DESCRIPTION
Changed `test.log` to `vmngclient.log` as default logging file.

Changed logging to add option for end user to set custom logging configuration and not overwrite those settings. If no custom settings are added `vmngclient` logs stay the same (only difference is logging file name).