### PR TITLE
bump poetry to 1.3.1, use --sync to clean-up dependencies

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,9 +14,9 @@ jobs:
     - name: Set Up Poetry
       uses: abatilo/actions-poetry@v2
       with:
-        poetry-version: 1.1.13
+        poetry-version: 1.3.1
     - name: Install dependencies
-      run: poetry install -v
+      run: poetry install --sync -v
     - name: Build HTML
       run: poetry run sphinx-build -M html docs/source docs/build
     - name: Upload artifacts

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Set Up Poetry
         uses: abatilo/actions-poetry@v2
         with:
-          poetry-version: 1.1.13
+          poetry-version: 1.3.1
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          poetry install -v
+          poetry install --sync -v
       - name: Checking if imports are sorted correctly
         run: poetry run isort --check --diff -l 120 --profile black vmngclient
       - name: Check static-typing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set Up Poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.13
+          poetry-version: 1.3.1
       - name: Publish vmngclient
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Set Up Poetry
         uses: abatilo/actions-poetry@v2
         with:
-          poetry-version: 1.1.13
+          poetry-version: 1.3.1
       - name: Install dependencies
-        run: poetry install -v
+        run: poetry install --sync -v
       - name: Run Tests
         run: poetry run pytest vmngclient/tests

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set Up Poetry
         uses: abatilo/actions-poetry@v2
         with:
-          poetry-version: 1.1.13
+          poetry-version: 1.3.1
       - name: Get old version
         run: |
           version_message=$(poetry version)

--- a/README.md
+++ b/README.md
@@ -94,15 +94,19 @@ Please contact authors direcly or via Issues Github page.
     ```
     git clone https://github.com/CiscoDevNet/vManage-client.git
     ```
-3. Install poetry v1.1.13
+3. Install poetry v1.3.1
     ```
-    pip install poetry==1.1.13
+    pip install poetry==1.3.1
     ```
-4. Install dependecies 
+4. Configure poetry to use virtual environments in project folder (can ease IDE integration)
+    ```
+    poetry config virtualenvs.in-project true
+    ```
+5. Install dependecies 
     ```
     poetry install
     ```
-5. Activate `pre-commit`
+6. Activate `pre-commit`
     ```
     pre-commit install
     ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,5 @@ flake8 = "^5.0.4"
 Sphinx = "^5.2.3"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.4.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
updating poetry to 1.3.1
- current version looks outdated: no docs for 1.1.13 (https://python-poetry.org/docs/)
- --sync option was missing in 1.1.13, makes venv dependecies locked and reproducible 