### PR TITLE
fix task_status_api

### DIFF
--- a/vmngclient/api/task_status_api.py
+++ b/vmngclient/api/task_status_api.py
@@ -1,4 +1,5 @@
 import logging
+from time import sleep
 from typing import List, cast
 
 from attr import define, field  # type: ignore
@@ -7,7 +8,6 @@ from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed  # t
 from vmngclient.session import vManageSession
 from vmngclient.utils.creation_tools import FIELD_NAME, create_dataclass
 from vmngclient.utils.operation_status import OperationStatus, OperationStatusId
-from time import sleep
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +94,7 @@ def wait_for_completed(
     def get_all_tasks():
         url = "dataservice/device/action/status/tasks"
         tasks = session.get_json(url)
-        return [process['processId'] for process in tasks['runningTasks']]
+        return [process["processId"] for process in tasks["runningTasks"]]
 
     def log_exception(self) -> None:
         logger.error("Operation status not achieved in given time")
@@ -123,8 +123,8 @@ def wait_for_completed(
                 try:
                     action_data = session.get_data(url)[0]
                 except IndexError:
-                    raise ValueError(f'task id {action_id} is not registered by vManage.')
-            raise ValueError(f'task id {action_id} is not registered by vManage.')
+                    raise ValueError(f"task id {action_id} is not registered by vManage.")
+            raise ValueError(f"task id {action_id} is not registered by vManage.")
 
         task = create_dataclass(TaskStatus, action_data)
         logger.debug(

--- a/vmngclient/api/task_status_api.py
+++ b/vmngclient/api/task_status_api.py
@@ -92,8 +92,8 @@ def wait_for_completed(
         return True
 
     def get_all_tasks():
-        url = "dataservice/device/status/tasks"
-        tasks = session.get_data(url)
+        url = "dataservice/device/action/status/tasks"
+        tasks = session.get_json(url)
         return [process['processId'] for process in tasks['runningTasks']]
 
     def log_exception(self) -> None:
@@ -116,13 +116,13 @@ def wait_for_completed(
         url = f"{action_url}{action_id}"
         try:
             action_data = session.get_data(url)[0]
-        except KeyError:
+        except IndexError:
             tasks_ids = get_all_tasks()
             if action_id in tasks_ids:
                 sleep(delay_seconds)
                 try:
                     action_data = session.get_data(url)[0]
-                except KeyError:
+                except IndexError:
                     raise ValueError(f'task id {action_id} is not registered by vManage.')
             raise ValueError(f'task id {action_id} is not registered by vManage.')
 


### PR DESCRIPTION
Additional steps for tasks_status_api:
    
1. Check if there is response from url = "/dataservice/device/action/status/{action_id}"
    2. if empty:
        Check if the task was registered:
        1. Check if action_id is inside list of running tasks from running_tasks_url
        2. If yes:
            1. introduce additional sleep (should be configurable via parameter to method, with some default value)
            3. If after addtitional sleep we still don't have proper response about task status -> raise error / return failure
        3. If no:   
            1. Raise Error / Return failure and info that the task was not registered
    3. if response is not empty, return task status