### PR TITLE
Session hook and logger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vmngclient"
-version = "0.4.0"
+version = "0.5.0"
 description = "Universal vManage API"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -4,7 +4,7 @@ import logging
 import time
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union, Callable
+from typing import Any, Callable, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
 from requests import Response, Session
@@ -14,7 +14,6 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fi
 
 from vmngclient.utils.response import response_debug
 from vmngclient.vmanage_auth import vManageAuth
-
 
 JSON = Union[Dict[str, "JSON"], List["JSON"], str, int, float, bool, None]
 
@@ -73,7 +72,7 @@ def create_vManageSession(
         vsession_id = session.get_virtual_session_id(tenant_id)
         session.headers.update({"VSessionId": vsession_id})
     server_info = session.server()
-    session.server_name = server_info.get('server')
+    session.server_name = server_info.get("server")
     session.on_session_create_hook()
 
     try:
@@ -120,6 +119,7 @@ class vManageSession(Session):
         username: username
         password: password
     """
+
     on_session_create_hook: Callable[[vManageSession], Any] = lambda *args: None
 
     def __init__(

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -4,7 +4,7 @@ import logging
 import time
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, ClassVar
 from urllib.parse import urljoin
 
 from requests import Response, Session
@@ -120,7 +120,7 @@ class vManageSession(Session):
         password: password
     """
 
-    on_session_create_hook: Callable[[vManageSession], Any] = lambda *args: None
+    on_session_create_hook: ClassVar[Callable[[vManageSession], Any]] = lambda *args: None
 
     def __init__(
         self,

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -4,7 +4,7 @@ import logging
 import time
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union, ClassVar
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
 from requests import Response, Session

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import time
 from enum import Enum, auto
-import pathlib
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, Callable
 from urllib.parse import urljoin
@@ -61,7 +60,6 @@ def create_vManageSession(
         password (str): password
         subdomain: subdomain specifying to which view switch when creating provider as a tenant session,
             works only on provider user mode
-        path (str): file to save logs
 
     Returns:
         Session object
@@ -69,7 +67,6 @@ def create_vManageSession(
     """
     session = vManageSession(url=url, username=username, password=password, port=port, subdomain=subdomain)
     session.auth = vManageAuth(session.base_url, username, password, verify=False)
-    session.on_session_create_hook()
 
     if subdomain:
         tenant_id = session.get_tenant_id()
@@ -77,6 +74,7 @@ def create_vManageSession(
         session.headers.update({"VSessionId": vsession_id})
     server_info = session.server()
     session.server_name = server_info.get('server')
+    session.on_session_create_hook()
 
     try:
         user_mode = UserMode(server_info.get("userMode", "not found"))

--- a/vmngclient/utils/response.py
+++ b/vmngclient/utils/response.py
@@ -25,7 +25,7 @@ class VManageResponseDebugInfo:
     response: Dict[str, Any]
 
 
-def response_debug(response: Response, headers: bool = False) -> str:
+def response_debug(response: Response, headers: bool = True) -> str:
     request_body = response.request.body
     if isinstance(request_body, bytes) and request_body.isascii():
         request_body = str(request_body, encoding="utf-8")


### PR DESCRIPTION
Added session hook and logger.

Also logs from requests to vManage now include headers.


Example usage of hook for adding logger handling:
```python
from vmngclient.session import create_vManageSession, vManageSession

def set_up_logger(session: vManageSession):
    """
    Simple function adding file handling to vmngclient logger.
    Logs from the client will be saved also to 'my_file.log'
    """
    my_handler= logging.FileHandler("my_file.log")
    my_handler.setLevel(logging.DEBUG)

    session.logger.addHandler(my_handler)

vManageSession.on_session_create_hook = set_up_logger

my_session = create_vManageSession(...)

...

```