### PR TITLE
logging improvements

### DIFF
--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -146,7 +146,9 @@ class vManageSession(Session):
         self.session_type = SessionType.NOT_DEFINED
         self.server_name = None
         self.logger = logging.getLogger(__name__)
-        self.response_trace: Callable[[Response, Union[Request, PreparedRequest, None]], str] = response_history_debug
+        self.response_trace: Callable[
+            [Optional[Response], Union[Request, PreparedRequest, None]], str
+        ] = response_history_debug
         super(vManageSession, self).__init__()
         self.__prepare_session(verify, auth)
 

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -7,13 +7,13 @@ from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
-from requests import Response, Session, head
+from requests import PreparedRequest, Request, Response, Session, head
 from requests.auth import AuthBase
-from requests.exceptions import ConnectionError, HTTPError
+from requests.exceptions import ConnectionError, HTTPError, RequestException
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed  # type: ignore
 
 from vmngclient.exceptions import InvalidOperationError
-from vmngclient.utils.response import response_debug
+from vmngclient.utils.response import response_history_debug
 from vmngclient.vmanage_auth import vManageAuth
 
 JSON = Union[Dict[str, "JSON"], List["JSON"], str, int, float, bool, None]
@@ -146,14 +146,17 @@ class vManageSession(Session):
         self.session_type = SessionType.NOT_DEFINED
         self.server_name = None
         self.logger = logging.getLogger(__name__)
-
+        self.response_trace: Callable[[Response, Union[Request, PreparedRequest, None]], str] = response_history_debug
         super(vManageSession, self).__init__()
         self.__prepare_session(verify, auth)
 
     def request(self, method, url, *args, **kwargs) -> Any:
         full_url = self.get_full_url(url)
-        response = super(vManageSession, self).request(method, full_url, *args, **kwargs)
-        self.logger.debug(response_debug(response))
+        try:
+            response = super(vManageSession, self).request(method, full_url, *args, **kwargs)
+            self.logger.debug(self.response_trace(response, None))
+        except RequestException as exception:
+            self.logger.debug(self.response_trace(exception.response, exception.request))
 
         if response.request.url and "passwordReset.html" in response.request.url:
             raise InvalidOperationError("Password must be changed to use this session.")

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -157,6 +157,8 @@ class vManageSession(Session):
             self.logger.debug(self.response_trace(response, None))
         except RequestException as exception:
             self.logger.debug(self.response_trace(exception.response, exception.request))
+            self.logger.error(exception)
+            raise
 
         if response.request.url and "passwordReset.html" in response.request.url:
             raise InvalidOperationError("Password must be changed to use this session.")

--- a/vmngclient/utils/response.py
+++ b/vmngclient/utils/response.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from pprint import pformat
-from typing import Any, Dict, List, Type, TypeVar, cast
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
 
-from requests import Response
+from requests import PreparedRequest, Request, Response
 from requests.exceptions import JSONDecodeError
 
 from vmngclient.utils.creation_tools import create_dataclass
@@ -25,26 +25,59 @@ class VManageResponseDebugInfo:
     response: Dict[str, Any]
 
 
-def response_debug(response: Response, headers: bool = True) -> str:
-    request_body = response.request.body
-    if isinstance(request_body, bytes) and request_body.isascii():
-        request_body = str(request_body, encoding="utf-8")
+def response_debug(response: Response, request: Union[Request, PreparedRequest, None]) -> str:
+    """Returns human readable string containing Request-Response contents (helpful for debugging).
+
+    Args:
+        response: Response object to be debugged (note it contains an PreparedRequest object already)
+        request: optional Request object to be debugged
+
+    Returns:
+        str
+    """
+    if request is None:
+        request = response.request
+        request_body = request.body
+    else:
+        request = request
+        request_body = None
     info = VManageResponseDebugInfo(
         request={
-            "method": response.request.method,
-            "url": response.request.url,
+            "method": request.method,
+            "url": request.url,
             "body": request_body,
+            "headers": dict(request.headers.items()),
         },
-        response={"status": response.status_code, "reason": response.reason},
+        response={
+            "status": response.status_code,
+            "reason": response.reason,
+            "headers": dict(response.headers.items()),
+        },
     )
-    if len(response.text) <= 1024:
-        info.response.update({"text": response.text})
-    else:
-        info.response.update({"text(trimmed)": response.text[:128]})
-    if headers:
-        info.request.update({"headers": dict(response.request.headers.items())})
-        info.response.update({"headers": dict(response.headers.items())})
-    return pformat(dict(info.__dict__.items()), width=80, indent=0)
+    try:
+        json = response.json()
+        json.pop("header", None)
+        info.response.update({"json": json})
+    except JSONDecodeError:
+        if len(response.text) <= 1024:
+            info.response.update({"text": response.text})
+        else:
+            info.response.update({"text(trimmed)": response.text[:128]})
+    return pformat(dict(info.__dict__.items()), width=80, sort_dicts=False)
+
+
+def response_history_debug(response: Response, request: Union[Request, PreparedRequest, None]) -> str:
+    """Returns human readable string containing Request-Response history contents for given response.
+
+    Args:
+        response: Response object to be debugged (note it contains an PreparedRequest object already)
+        request: optional Request object to be debugged (considered to be latest request)
+
+    Returns:
+        str
+    """
+    response_debugs = [response_debug(resp, None) for resp in response.history] + [response_debug(response, request)]
+    return "\n".join(response_debugs)
 
 
 def get_json_data(response: Response) -> Any:


### PR DESCRIPTION
1. when redirect occur whole history is logged
2. logs request content also on RequestExceptions (ConnectionError, Timeout, etc.)
3. logging format can be modified externally by assigning response-to-string converter method in vManageSession class:
```python
self.response_trace: Callable[[Response, Union[Request, PreparedRequest, None]], str] = response_history_debug
```
4. default formatting changed
4.1 when json present in payload it will be parsed ("header" object of json payload is filtered out explicitly)