### PR TITLE
enable default logger config only when env var is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Please contact authors direcly or via Issues Github page.
     ```
     pre-commit install
     ```
-### **Environmet Variables**
+### **Environment Variables**
 - **`VMNGCLIENT_DEVEL`** when set: loggers will be configured according to `./logging.conf` and `urllib3.exceptions.InsecureRequestWarning` will be suppressed
 
 ## **Add new feature**

--- a/README.md
+++ b/README.md
@@ -102,11 +102,6 @@ Please contact authors direcly or via Issues Github page.
     curl -sSL https://install.python-poetry.org | python3 -
     poetry config virtualenvs.in-project true
     ```
-    Depending on your IDE you might at this point think about proper integration
-
-    https://www.jetbrains.com/help/pycharm/poetry.html
-
-    https://code.visualstudio.com/docs/python/environments
 4. Install dependecies 
     ```
     poetry install
@@ -115,6 +110,8 @@ Please contact authors direcly or via Issues Github page.
     ```
     pre-commit install
     ```
+### **Environmet Variables**
+- **`VMNGCLIENT_DEVEL`** when set: loggers will be configured according to `./logging.conf` and `urllib3.exceptions.InsecureRequestWarning` will be suppressed
 
 ## **Add new feature**
 To add new feature create new branch and implement it. Before making a pull request make sure that `pre-commit` passes.

--- a/vmngclient/__init__.py
+++ b/vmngclient/__init__.py
@@ -1,16 +1,17 @@
 import logging
 import logging.config
 from importlib import metadata
+from os import environ
 from pathlib import Path
 from typing import Final
 
+import urllib3
+
 LOGGING_CONF_DIR: Final[str] = str(Path(__file__).parents[0] / "logging.conf")
-
-vmngclient_logger = logging.getLogger(__name__)
-
-if not vmngclient_logger.handlers:
-    logging.config.fileConfig(LOGGING_CONF_DIR, disable_existing_loggers=False)
-
 __version__ = metadata.version(__package__)
 
-vmngclient_logger.debug(f"vmngclient {__version__}")
+if environ.get("VMNGCLIENT_DEVEL") is not None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    vmngclient_logger = logging.getLogger(__name__)
+    logging.config.fileConfig(LOGGING_CONF_DIR, disable_existing_loggers=False)
+    vmngclient_logger.debug(f"vmngclient {__version__}")


### PR DESCRIPTION
Sometimes creating `vmngclient.log` in current working directory is not desired and currently cannot be prevented.
Propose to control logging setting via env variable, which indicates that we are in "development" mode.
Added explanation in `README.md`:
### **Environment Variables**
- **`VMNGCLIENT_DEVEL`** when set: loggers will be configured according to `./logging.conf` and `urllib3.exceptions.InsecureRequestWarning` will be suppressed
