### PR TITLE
add process id and caller info to debug trace

### DIFF
--- a/vmngclient/__init__.py
+++ b/vmngclient/__init__.py
@@ -1,14 +1,52 @@
 import logging
 import logging.config
+from functools import lru_cache
 from importlib import metadata
+from importlib.machinery import PathFinder
 from os import environ
 from pathlib import Path
-from typing import Final
+from traceback import FrameSummary, StackSummary
+from typing import Final, List
 
 import urllib3
 
+
+def get_first_external_stack_frame(stack: StackSummary) -> FrameSummary:
+    """
+    Get the first python frame
+    on the stack before entering vmngclient module
+    """
+    for index, frame in enumerate(stack):
+        if is_file_in_package(frame.filename):
+            break
+    return stack[index - 1]
+
+
+@lru_cache()
+def is_file_in_package(fname: str) -> bool:
+    """
+    Checks if filepath given by string
+    is part of vmngclient source code
+    """
+    return Path(fname) in pkg_src_list
+
+
+def list_package_sources() -> List[Path]:
+    """
+    Creates a list containing paths to all python source files
+    for current package
+    """
+    pkg_srcs: List[Path] = []
+    if pkg_spec := PathFinder.find_spec(__package__):
+        if pkg_origin := pkg_spec.origin:
+            pkg_srcs = list(Path(pkg_origin).parent.glob("**/*.py"))
+    return pkg_srcs
+
+
 LOGGING_CONF_DIR: Final[str] = str(Path(__file__).parents[0] / "logging.conf")
 __version__ = metadata.version(__package__)
+pkg_src_list = list_package_sources()
+
 
 if environ.get("VMNGCLIENT_DEVEL") is not None:
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

--- a/vmngclient/response.py
+++ b/vmngclient/response.py
@@ -1,11 +1,14 @@
+import multiprocessing
 from functools import wraps
 from pprint import pformat
+from traceback import extract_stack
 from typing import Any, Callable, Optional, Sequence, Type, TypeVar, Union, cast
 
 from attr import define  # type: ignore
 from requests import PreparedRequest, Request, Response
 from requests.exceptions import JSONDecodeError
 
+from vmngclient import get_first_external_stack_frame
 from vmngclient.dataclasses import DataclassBase
 from vmngclient.typed_list import DataSequence
 from vmngclient.utils.creation_tools import create_dataclass
@@ -18,6 +21,22 @@ class ErrorInfo(DataclassBase):
     message: str
     details: str
     code: str
+
+
+def with_proc_info_header(method: Callable[..., str]) -> Callable[..., str]:
+    """
+    Adds process ID and external caller information before first line of returned string
+    """
+
+    @wraps(method)
+    def wrapper(*args, **kwargs) -> str:
+        wrapped = method(*args, **kwargs)
+        fname, line_no, function, _ = get_first_external_stack_frame(extract_stack())
+        external_caller_info = "%s:%d %s(...)" % (fname, line_no, function)
+        header = f"{multiprocessing.current_process()} {external_caller_info}\n"
+        return header + wrapped
+
+    return wrapper
 
 
 def response_debug(response: Optional[Response], request: Union[Request, PreparedRequest, None]) -> str:
@@ -67,6 +86,7 @@ def response_debug(response: Optional[Response], request: Union[Request, Prepare
     return pformat(debug_dict, width=80, sort_dicts=False)
 
 
+@with_proc_info_header
 def response_history_debug(response: Optional[Response], request: Union[Request, PreparedRequest, None]) -> str:
     """Returns human readable string containing Request-Response history contents for given response.
 


### PR DESCRIPTION
Adds Process ID and caller information as first line of debug trace:
```
2023-03-01 18:23:43 - vmngclient.session - DEBUG - <_MainProcess name='MainProcess' parent=None started> /Users/sbasan/repos/vManage-client/applib.py:9 get_foo(...)
{'request': {'method': 'GET',
             'url': 'https://10.0.0.1:10100/dataservice/foo',
             'headers': {'User-Agent': 'python-requests/2.28.2',
                         'Accept-Encoding': 'gzip, deflate',
                         'Accept': '*/*',
                         'Connection': 'keep-alive',
                         'Cookie': 'JSESSIONID=6z88PHZF5TEoL5ok3boMM9H503_nGDZCSWLgnb.69a694ab-e0-4075-a83e-c4635558371c',
                         'x-xsrf-token': '38FD7666390FE0D7BFEBCE00BAF53C5E6937A95FDEE7602D0D99F457728B8CF9FA233B6A961F2A29629FD66DC1855148'}},
 'response': {'status': 404,
              'reason': 'Not Found',
              'headers': {'content-encoding': 'gzip',
```