### PR TITLE
ratelimit adaptations

### DIFF
--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -4,7 +4,7 @@ import logging
 import time
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Protocol, Union
 from urllib.parse import urljoin
 
 from requests import PreparedRequest, Request, Response, Session, head
@@ -43,6 +43,21 @@ class ViewMode(Enum):
 
 class SessionNotCreatedError(Exception):
     pass
+
+
+class OnSessionCreateHook(Protocol):
+    def __call__(self) -> None:
+        ...
+
+
+class OnRequestHook(Protocol):
+    def __call__(self, method: str, url: Union[str, bytes], *args, **kwargs) -> None:
+        ...
+
+
+class ResponseTrace(Protocol):
+    def __call__(self, response: Optional[Response], request: Union[Request, PreparedRequest, None]) -> str:
+        ...
 
 
 def create_vManageSession(
@@ -142,7 +157,8 @@ class vManageSession(vManageResponseAdapter):
         password: password
     """
 
-    on_session_create_hook: ClassVar[Callable[[vManageSession], Any]] = lambda *args: None
+    on_session_create_hook: OnSessionCreateHook = lambda *args: None
+    on_request_hook: OnRequestHook = lambda *args, **kwargs: None
 
     def __init__(
         self,
@@ -164,9 +180,9 @@ class vManageSession(vManageResponseAdapter):
         self._session_type = SessionType.NOT_DEFINED
         self.server_name = None
         self.logger = logging.getLogger(__name__)
-        self.response_trace: Callable[
-            [Optional[Response], Union[Request, PreparedRequest, None]], str
-        ] = response_history_debug
+        self.response_trace: ResponseTrace = response_history_debug
+        self.on_session_create_hook: OnSessionCreateHook = vManageSession.on_session_create_hook
+        self.on_request_hook: OnRequestHook = vManageSession.on_request_hook
         super(vManageSession, self).__init__()
         self.__prepare_session(verify, auth)
 
@@ -174,6 +190,7 @@ class vManageSession(vManageResponseAdapter):
 
     def request(self, method, url, *args, **kwargs) -> vManageResponse:
         full_url = self.get_full_url(url)
+        self.on_request_hook(method, full_url)
         try:
             response = super(vManageSession, self).request(method, full_url, *args, **kwargs)
             self.logger.debug(self.response_trace(response, None))

--- a/vmngclient/utils/ratelimit.py
+++ b/vmngclient/utils/ratelimit.py
@@ -1,0 +1,93 @@
+"""
+This is utility module which can be help to limit requests rate globally (from multiple sessions, threads and processes)
+To enable ratelimiting for all requests sent from vmanage-client in your application:
+>>> from vmngclient.utils.ratelimit import ratelimit, on_request_throttle
+>>> ratelimit(100)
+>>> vManageSession.on_request_hook = on_request_throttle
+>>> vManageAuth.on_request_hook = on_request_throttle
+"""
+
+import multiprocessing
+import threading
+import time
+from ipaddress import IPv4Address, IPv6Address, ip_address
+from socket import getaddrinfo
+from typing import Dict, Union
+from urllib.parse import urlparse
+
+DEFAULT_MAX_REQUESTS_PER_MINUTE = 1000
+max_requests_per_minute_setting = DEFAULT_MAX_REQUESTS_PER_MINUTE
+
+
+class RateLimiter:
+    def __init__(self, max_requests_per_minute: int):
+        self.tlock = threading.Lock()
+        self.mplock = multiprocessing.Lock()
+        self.last_request_timestamp = 0.0
+        self.max_requests_per_minute = max_requests_per_minute
+
+    @property
+    def max_requests_per_minute(self):
+        return self._max_requests_per_minute
+
+    @max_requests_per_minute.setter
+    def max_requests_per_minute(self, rpm: int):
+        self._max_requests_per_minute = rpm
+        self.min_interval = 60.0 / float(rpm)
+
+    def block(self):
+        # ensures that each call is separated with min_interval
+        with self.tlock:
+            with self.mplock:
+                elapsed = time.monotonic() - self.last_request_timestamp
+                left_to_wait = self.min_interval - elapsed
+                if left_to_wait > 0:
+                    time.sleep(left_to_wait)
+                self.last_request_timestamp = time.monotonic()
+
+
+ratelimiters: Dict[Union[IPv4Address, IPv6Address, None], RateLimiter] = {}
+
+
+def url_to_host(url: str) -> Union[IPv4Address, IPv6Address, None]:
+    """
+    Takes url like "http://apple.fruits.com:3333/dataservice/foo"
+    And returns host IP Address
+    """
+    host, _, port = urlparse(url).netloc.partition(":")
+    addrinfos = getaddrinfo(host, port)
+    return ip_address(addrinfos[0][4][0])
+
+
+def ratelimit(max_requests_per_minute: int, host: Union[IPv4Address, IPv6Address, None] = None):
+    """
+    Sets or changes ratelimit for given IP host
+    If host not provided it changes default ratelimit setting for new ratelimiters
+    (ratelimiters can be created automatically on traffic by throttle function)
+    """
+    global ratelimiters
+    global max_requests_per_minute_setting
+    if not host:
+        max_requests_per_minute_setting = max_requests_per_minute
+    if not ratelimiters.get(host):
+        ratelimiters[host] = RateLimiter(max_requests_per_minute)
+    else:
+        ratelimiters[host].max_requests_per_minute = max_requests_per_minute
+
+
+def throttle(host: Union[IPv4Address, IPv6Address, None] = None):
+    """
+    Ensures that each call is separated with min_interval for given Host
+    One ratelimiter is shared for all throttle calls when host is not provided
+    """
+    global ratelimiters
+    if not ratelimiters.get(host):
+        ratelimiters[host] = RateLimiter(max_requests_per_minute_setting)
+    ratelimiters[host].block()
+
+
+def on_request_throttle(method: str, url: str, *args, **kwargs):
+    """
+    Example of function performing throttle with matching signature of vmngclient.session.OnRequestHook
+    """
+    throttle(url_to_host(url))


### PR DESCRIPTION
Created `on_request_hook` for `vManageSession` and `vManageAuth` which allows to attach custom user function which will be executed right before request is sent to vmanage.
Hooks can be assigned at class level (will attach to every new instance) or can be assigned at instance level.
Added `ratelimit` utility module which demonstrates how global ratelimiting using `on_request_hook` can be implemented:
```python
from vmngclient.utils.ratelimit import ratelimit, on_request_throttle
ratelimit(100)
vManageSession.on_request_hook = on_request_throttle
vManageAuth.on_request_hook = on_request_throttle
```