### PR TITLE
[feature template] fix for j2 tunnel

### DIFF
--- a/vmngclient/api/templates/payloads/cisco_vpn_interface_ethernet/feature/tunnel.json.j2
+++ b/vmngclient/api/templates/payloads/cisco_vpn_interface_ethernet/feature/tunnel.json.j2
@@ -10,7 +10,7 @@
                     "vipType": "constant",
                     "vipValue": {{ encap.preference }},
                 {% else %}
-                    "vipType": "ignore"
+                    "vipType": "ignore",
                 {% endif %} 
                 "vipVariableName": "vpn_if_tunnel_{{ encap.type.value }}_preference"
               },
@@ -20,7 +20,7 @@
                     "vipType": "constant",
                     "vipValue": {{ encap.weight }},
                 {% else %}
-                    "vipType": "ignore"
+                    "vipType": "ignore",
                     "vipValue": 1,
                 {% endif %} 
                 "vipVariableName": "vpn_if_tunnel_{{ encap.type.value }}_weight"


### PR DESCRIPTION
Example used to test it:
```python
template_api = TemplatesAPI(session)

encapsulation = [
  Encapsulation(EncapType.GRE),
  Encapsulation(EncapType.IPSEC, preference=1, weight=1),
]

tunnel_1 = Tunnel(
    color = ColorType.G3,
    encapsulation = encapsulation
)

ipv4_eth3 = TypeAddress("static")
vpn_0_eth1 = CiscoVpnInterfaceEthernetModel(
    name="vm81_vpn_0_gigabitethernet3",
    description="vm81_vpn_0_gigabitethernet3",
    shutdown = False,
    tunnel = tunnel_1,
    interface_name = "GigabitEthernet",
    type_address = ipv4_eth3,
    mtu = 1500,
    autonegotiate = True
)
```