### PR TITLE
[feature template] enable static ip and interface name

### DIFF
--- a/vmngclient/api/templates/payloads/cisco_vpn_interface_ethernet/cisco_vpn_interface_ethernet_model.py
+++ b/vmngclient/api/templates/payloads/cisco_vpn_interface_ethernet/cisco_vpn_interface_ethernet_model.py
@@ -63,6 +63,12 @@ class EncapType(Enum):
 
 
 @define
+class InterfaceName:
+    type: InterfaceType
+    number: Optional[str] = None
+
+
+@define
 class Encapsulation:
     type: EncapType
     preference: Optional[int] = None
@@ -89,7 +95,7 @@ class Tunnel:
 
 class CiscoVpnInterfaceEthernetModel(FeatureTemplate):
     payload_path: ClassVar[Path] = Path(__file__).parent / "feature/cisco_vpn_interface_ethernet.json.j2"
-    interface_name: InterfaceType
+    interface_name: InterfaceName
     shutdown: Optional[bool]
     type_address: TypeAddress = TypeAddress.STATIC
     ip: Optional[str]

--- a/vmngclient/api/templates/payloads/cisco_vpn_interface_ethernet/feature/cisco_vpn_interface_ethernet.json.j2
+++ b/vmngclient/api/templates/payloads/cisco_vpn_interface_ethernet/feature/cisco_vpn_interface_ethernet.json.j2
@@ -8,7 +8,7 @@
   "templateMinVersion": "15.0.0",
   "templateDefinition": {
     "ip": {
-      {% if type_address == "static" %}
+      {% if type_address.value == "static" %}
         "address": {
           "vipObjectType": "object",
           {% if ip is defined %}

--- a/vmngclient/api/templates/payloads/cisco_vpn_interface_ethernet/feature/cisco_vpn_interface_ethernet.json.j2
+++ b/vmngclient/api/templates/payloads/cisco_vpn_interface_ethernet/feature/cisco_vpn_interface_ethernet.json.j2
@@ -40,7 +40,7 @@
     "if-name": {
       "vipObjectType": "object",
       "vipType": "constant",
-      "vipValue": "{{ interface_name.value }}",
+      "vipValue": "{{ interface_name.type.value }}{% if interface_name.number is not none %}{{ interface_name.number }}{% endif %}",
       "vipVariableName": "vpn_if_name"
     },
     "description": {


### PR DESCRIPTION
Example used:

```python
encapsulation = [
  Encapsulation(EncapType.GRE),
  Encapsulation(EncapType.IPSEC, preference=1, weight=1),
]

template_api = TemplatesAPI(session)
tunnel_1 = Tunnel(
    color = ColorType.G3,
    encapsulation = encapsulation
)

ipv4_eth3 = TypeAddress("static")
vpn_0_eth1 = CiscoVpnInterfaceEthernetModel(
    name="vm81_vpn_0_gigabitethernet2235",
    description="vm81_vpn_0_gigabitethernet3",
    shutdown = False,
    tunnel = tunnel_1,
    interface_name = InterfaceName(InterfaceType.GIGABIT_ETHERNET, "2"),
    ip="10.101.81.81/24",
    type_address = ipv4_eth3,
    mtu = 1500,
    autonegotiate = True
)

```