### PR TITLE
ratelimit adaptations

### DIFF
--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -46,7 +46,7 @@ class SessionNotCreatedError(Exception):
 
 
 class OnSessionCreateHook(Protocol):
-    def __call__(self) -> None:
+    def __call__(self, session: Session) -> None:
         ...
 
 
@@ -100,7 +100,7 @@ def create_vManageSession(
         server_info = {}
 
     session.server_name = server_info.get("server")
-    session.on_session_create_hook()
+    session.on_session_create_hook(session)
 
     try:
         user_mode = UserMode(server_info.get("userMode", "not found"))
@@ -195,7 +195,7 @@ class vManageSession(vManageResponseAdapter):
 
     def request(self, method, url, *args, **kwargs) -> vManageResponse:
         full_url = self.get_full_url(url)
-        self.on_request_hook(method, full_url)
+        self.on_request_hook(method, full_url, *args, **kwargs)
         try:
             response = super(vManageSession, self).request(method, full_url, *args, **kwargs)
             self.logger.debug(self.response_trace(response, None))

--- a/vmngclient/tests/test_utils_ratelimit.py
+++ b/vmngclient/tests/test_utils_ratelimit.py
@@ -1,32 +1,38 @@
+import logging
+import time
 import unittest
 from ipaddress import ip_address
+from multiprocessing import set_start_method
+from multiprocessing.pool import Pool, ThreadPool
 from unittest.mock import patch
 
 from parameterized import parameterized  # type: ignore
 
 from vmngclient.utils.ratelimit import (
-    DEFAULT_MAX_REQUESTS_PER_MINUTE,
-    max_requests_per_minute_setting,
+    DEFAULT_MAX_REQUESTS_PER_SECOND,
+    max_requests_per_second_setting,
     on_request_throttle,
     ratelimit,
     ratelimiters,
     throttle,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class TestUtilsRateLimit(unittest.TestCase):
     def setUp(self) -> None:
         global ratelimiter
         ratelimiters.clear()
-        ratelimit(DEFAULT_MAX_REQUESTS_PER_MINUTE)
+        ratelimit(DEFAULT_MAX_REQUESTS_PER_SECOND)
         return super().setUp()
 
     def test_default_ratelimiter(self):
-        ratelimit(max_requests_per_minute=100)
-        assert ratelimiters[None].max_requests_per_minute == 100
-        assert ratelimiters[None].min_interval == 60.0 / 100.0
-        ratelimiters[None].max_requests_per_minute = 700
-        assert ratelimiters[None].min_interval == 60.0 / 700.0
+        ratelimit(max_requests_per_second=100)
+        assert ratelimiters[None].max_requests_per_second == 100
+        assert ratelimiters[None].min_interval == 1 / 100.0
+        ratelimiters[None].max_requests_per_second = 700
+        assert ratelimiters[None].min_interval == 1 / 700.0
 
     @parameterized.expand(
         [
@@ -40,8 +46,8 @@ class TestUtilsRateLimit(unittest.TestCase):
     @patch("socket.gethostbyaddr")
     def test_create_per_host_ratelimiters(self, rate, ip, mock_gethostbyaddr):
         mock_gethostbyaddr.return_value = str(ip)
-        ratelimit(max_requests_per_minute=rate, host=ip)
-        assert ratelimiters[ip].max_requests_per_minute == rate
+        ratelimit(max_requests_per_second=rate, host=ip)
+        assert ratelimiters[ip].max_requests_per_second == rate
 
     @parameterized.expand(
         [
@@ -56,7 +62,7 @@ class TestUtilsRateLimit(unittest.TestCase):
     def test_throttle_with_default_rate(self, ip, mock_gethostbyaddr):
         mock_gethostbyaddr.return_value = str(ip)
         throttle(host=ip)
-        assert ratelimiters[ip].max_requests_per_minute == max_requests_per_minute_setting
+        assert ratelimiters[ip].max_requests_per_second == max_requests_per_second_setting
 
     @parameterized.expand(
         [
@@ -70,6 +76,31 @@ class TestUtilsRateLimit(unittest.TestCase):
     @patch("socket.gethostbyaddr")
     def test_on_request_throttle_preset_rate(self, rate, url, ip, mock_gethostbyaddr):
         mock_gethostbyaddr.return_value = str(ip)
-        ratelimit(max_requests_per_minute=rate, host=ip)
+        ratelimit(max_requests_per_second=rate, host=ip)
         on_request_throttle(method="get", url=url)
-        assert ratelimiters[ip].max_requests_per_minute == rate
+        assert ratelimiters[ip].max_requests_per_second == rate
+
+    @patch("socket.gethostbyaddr")
+    def test_throttle_multiple_threads_and_processes(self, mock_gethostbyaddr):
+        # Given
+        ip = ip_address("127.0.0.2")
+        mock_gethostbyaddr.return_value = str(ip)
+        mp_items = [ip] * 3
+        t_items = [ip] * 4
+        item_count = len(mp_items) + len(t_items)
+        max_rps = 9
+        ratelimit(max_requests_per_second=max_rps)
+        min_expected_time_to_finish_tasks = item_count * 1.0 / max_rps
+        set_start_method("fork")
+        # Act
+        start = time.monotonic()
+        mp_results = Pool(len(mp_items)).map_async(throttle, mp_items)
+        t_results = ThreadPool(len(t_items)).map_async(throttle, t_items)
+        mp_results.wait()
+        t_results.wait()
+        finish = time.monotonic()
+        delta = finish - start
+        assert finish - start > min_expected_time_to_finish_tasks, (
+            f"{item_count} tasks finished in {delta:.2f}s, "
+            f"but expected no earlier than: {min_expected_time_to_finish_tasks:.2f}s for given rate {max_rps}/s"
+        )

--- a/vmngclient/tests/test_utils_ratelimit.py
+++ b/vmngclient/tests/test_utils_ratelimit.py
@@ -2,7 +2,6 @@ import logging
 import time
 import unittest
 from ipaddress import ip_address
-from multiprocessing import set_start_method
 from multiprocessing.pool import Pool, ThreadPool
 from unittest.mock import patch
 
@@ -10,10 +9,10 @@ from parameterized import parameterized  # type: ignore
 
 from vmngclient.utils.ratelimit import (
     DEFAULT_MAX_REQUESTS_PER_SECOND,
-    max_requests_per_second_setting,
+    _load_ratelimit_data,
+    clear,
     on_request_throttle,
     ratelimit,
-    ratelimiters,
     throttle,
 )
 
@@ -23,12 +22,13 @@ logger = logging.getLogger(__name__)
 class TestUtilsRateLimit(unittest.TestCase):
     def setUp(self) -> None:
         global ratelimiter
-        ratelimiters.clear()
+        clear()
         ratelimit(DEFAULT_MAX_REQUESTS_PER_SECOND)
         return super().setUp()
 
     def test_default_ratelimiter(self):
         ratelimit(max_requests_per_second=100)
+        ratelimiters = _load_ratelimit_data()
         assert ratelimiters[None].max_requests_per_second == 100
         assert ratelimiters[None].min_interval == 1 / 100.0
         ratelimiters[None].max_requests_per_second = 700
@@ -47,6 +47,7 @@ class TestUtilsRateLimit(unittest.TestCase):
     def test_create_per_host_ratelimiters(self, rate, ip, mock_gethostbyaddr):
         mock_gethostbyaddr.return_value = str(ip)
         ratelimit(max_requests_per_second=rate, host=ip)
+        ratelimiters = _load_ratelimit_data()
         assert ratelimiters[ip].max_requests_per_second == rate
 
     @parameterized.expand(
@@ -62,7 +63,8 @@ class TestUtilsRateLimit(unittest.TestCase):
     def test_throttle_with_default_rate(self, ip, mock_gethostbyaddr):
         mock_gethostbyaddr.return_value = str(ip)
         throttle(host=ip)
-        assert ratelimiters[ip].max_requests_per_second == max_requests_per_second_setting
+        ratelimiters = _load_ratelimit_data()
+        assert ratelimiters[ip].max_requests_per_second == ratelimiters.default_rps
 
     @parameterized.expand(
         [
@@ -78,6 +80,7 @@ class TestUtilsRateLimit(unittest.TestCase):
         mock_gethostbyaddr.return_value = str(ip)
         ratelimit(max_requests_per_second=rate, host=ip)
         on_request_throttle(method="get", url=url)
+        ratelimiters = _load_ratelimit_data()
         assert ratelimiters[ip].max_requests_per_second == rate
 
     @patch("socket.gethostbyaddr")
@@ -85,13 +88,12 @@ class TestUtilsRateLimit(unittest.TestCase):
         # Given
         ip = ip_address("127.0.0.2")
         mock_gethostbyaddr.return_value = str(ip)
-        mp_items = [ip] * 3
-        t_items = [ip] * 4
+        mp_items = [ip] * 33
+        t_items = [ip] * 31
         item_count = len(mp_items) + len(t_items)
-        max_rps = 9
+        max_rps = 3
         ratelimit(max_requests_per_second=max_rps)
         min_expected_time_to_finish_tasks = item_count * 1.0 / max_rps
-        set_start_method("fork")
         # Act
         start = time.monotonic()
         mp_results = Pool(len(mp_items)).map_async(throttle, mp_items)

--- a/vmngclient/tests/test_utils_ratelimit.py
+++ b/vmngclient/tests/test_utils_ratelimit.py
@@ -1,0 +1,75 @@
+import unittest
+from ipaddress import ip_address
+from unittest.mock import patch
+
+from parameterized import parameterized  # type: ignore
+
+from vmngclient.utils.ratelimit import (
+    DEFAULT_MAX_REQUESTS_PER_MINUTE,
+    max_requests_per_minute_setting,
+    on_request_throttle,
+    ratelimit,
+    ratelimiters,
+    throttle,
+)
+
+
+class TestTypedList(unittest.TestCase):
+    def setUp(self) -> None:
+        global ratelimiter
+        ratelimiters.clear()
+        ratelimit(DEFAULT_MAX_REQUESTS_PER_MINUTE)
+        return super().setUp()
+
+    def test_default_ratelimiter(self):
+        ratelimit(max_requests_per_minute=100)
+        assert ratelimiters[None].max_requests_per_minute == 100
+        assert ratelimiters[None].min_interval == 60.0 / 100.0
+        ratelimiters[None].max_requests_per_minute = 700
+        assert ratelimiters[None].min_interval == 60.0 / 700.0
+
+    @parameterized.expand(
+        [
+            (15, ip_address("127.0.0.9")),
+            (85, ip_address("127.0.0.9")),
+            (11, None),
+            (99, ip_address("2001:db8:3333:4444:5555:6666:7777:8888")),
+            (32, ip_address("127.0.2.22")),
+        ]
+    )
+    @patch("socket.gethostbyaddr")
+    def test_create_per_host_ratelimiters(self, rate, ip, mock_gethostbyaddr):
+        mock_gethostbyaddr.return_value = str(ip)
+        ratelimit(max_requests_per_minute=rate, host=ip)
+        assert ratelimiters[ip].max_requests_per_minute == rate
+
+    @parameterized.expand(
+        [
+            (ip_address("127.0.0.9"),),
+            (ip_address("127.0.0.9"),),
+            (None,),
+            (ip_address("2001:db8:3333:4444:5555:6666:7777:8888"),),
+            (ip_address("127.0.2.22"),),
+        ]
+    )
+    @patch("socket.gethostbyaddr")
+    def test_throttle_with_default_rate(self, ip, mock_gethostbyaddr):
+        mock_gethostbyaddr.return_value = str(ip)
+        throttle(host=ip)
+        assert ratelimiters[ip].max_requests_per_minute == max_requests_per_minute_setting
+
+    @parameterized.expand(
+        [
+            (3333, "http://localhost:333/foo", ip_address("127.0.0.9")),
+            (8818, b"127.0.0.9:80/foo", ip_address("127.0.0.9")),
+            (8978, "{/?>>}/7897/89-=/57/8", None),
+            (9556, "www.google.com", ip_address("2001:db8:3333:4444:5555:6666:7777:8888")),
+            (1111, "https://127.0.2.22/#", ip_address("127.0.2.22")),
+        ]
+    )
+    @patch("socket.gethostbyaddr")
+    def test_on_request_throttle_preset_rate(self, rate, url, ip, mock_gethostbyaddr):
+        mock_gethostbyaddr.return_value = str(ip)
+        ratelimit(max_requests_per_minute=rate, host=ip)
+        on_request_throttle(method="get", url=url)
+        assert ratelimiters[ip].max_requests_per_minute == rate

--- a/vmngclient/tests/test_utils_ratelimit.py
+++ b/vmngclient/tests/test_utils_ratelimit.py
@@ -14,7 +14,7 @@ from vmngclient.utils.ratelimit import (
 )
 
 
-class TestTypedList(unittest.TestCase):
+class TestUtilsRateLimit(unittest.TestCase):
     def setUp(self) -> None:
         global ratelimiter
         ratelimiters.clear()

--- a/vmngclient/utils/ratelimit.py
+++ b/vmngclient/utils/ratelimit.py
@@ -1,0 +1,93 @@
+"""
+This is utility module which can be help to limit requests rate globally (from multiple sessions, threads and processes)
+To enable ratelimiting for all requests sent from vmanage-client in your application:
+>>> from vmngclient.utils.ratelimit import ratelimit, on_request_throttle
+>>> ratelimit(100)
+>>> vManageSession.on_request_hook = on_request_throttle
+>>> vManageAuth.on_request_hook = on_request_throttle
+"""
+
+import multiprocessing
+import threading
+import time
+from ipaddress import IPv4Address, IPv6Address, ip_address
+from socket import getaddrinfo
+from typing import Dict, Union
+from urllib.parse import urlparse
+
+DEFAULT_MAX_REQUESTS_PER_MINUTE = 1000
+max_requests_per_minute_setting = DEFAULT_MAX_REQUESTS_PER_MINUTE
+
+
+class RateLimiter:
+    def __init__(self, max_requests_per_minute: int):
+        self.tlock = threading.Lock()
+        self.mplock = multiprocessing.Lock()
+        self.last_request_timestamp = 0.0
+        self.max_requests_per_minute = max_requests_per_minute
+
+    @property
+    def max_requests_per_minute(self):
+        return self._max_requests_per_minute
+
+    @max_requests_per_minute.setter
+    def max_requests_per_minute(self, rpm: int):
+        self._max_requests_per_minute = rpm
+        self.min_interval = 60.0 / float(rpm)
+
+    def block(self):
+        # ensures that each call is separated with min_interval
+        with self.tlock:
+            with self.mplock:
+                elapsed = time.monotonic() - self.last_request_timestamp
+                left_to_wait = self.min_interval - elapsed
+                if left_to_wait > 0:
+                    time.sleep(left_to_wait)
+                self.last_request_timestamp = time.monotonic()
+
+
+ratelimiters: Dict[Union[IPv4Address, IPv6Address, None], RateLimiter] = {}
+
+
+def url_to_host(url: str) -> Union[IPv4Address, IPv6Address, None]:
+    """
+    Takes url like "http://apple.fruits.com:3333/dataservice/foo"
+    And returns host IP Address
+    """
+    host, _, port = urlparse(url).netloc.partition(":")
+    addrinfos = getaddrinfo(host, port)
+    return ip_address(addrinfos[0][4][0])
+
+
+def ratelimit(max_requests_per_minute: int, host: Union[IPv4Address, IPv6Address, None] = None):
+    """
+    Sets or changes ratelimit for given IP host
+    If host not provided it changes default ratelimit setting for new ratelimiters
+    (ratelimiters can be created automatically on traffic by throttle function)
+    """
+    global ratelimiters
+    global max_requests_per_minute_setting
+    if not host:
+        max_requests_per_minute_setting = max_requests_per_minute
+    if not ratelimiters.get(host):
+        ratelimiters[host] = RateLimiter(max_requests_per_minute)
+    else:
+        ratelimiters[host].max_requests_per_minute = max_requests_per_minute
+
+
+def throttle(host: Union[IPv4Address, IPv6Address, None] = None):
+    """
+    Ensures that each call is separated with min_interval for given Host
+    One ratelimiter is shared for all throttle calls when host is not provided
+    """
+    global ratelimiters
+    if not ratelimiters.get(host):
+        ratelimiters[host] = RateLimiter(max_requests_per_minute_setting)
+    ratelimiters[host].block()
+
+
+def on_request_throttle(method: str, url: str, *args, **kwargs):
+    """
+    Example of function performing throttle with matching signature of vmngclient.session.OnRequestHook
+    """
+    throttle(url_to_host(url))

--- a/vmngclient/utils/ratelimit.py
+++ b/vmngclient/utils/ratelimit.py
@@ -2,7 +2,7 @@
 This is utility module which can be used to limit requests rate globally (from multiple sessions, threads and processes)
 To enable ratelimiting for all requests sent from vmanage-client in your application:
 >>> from vmngclient.utils.ratelimit import ratelimit, on_request_throttle
->>> ratelimit(max_requests_per_minute=100)
+>>> ratelimit(max_requests_per_second=100)
 >>> vManageSession.on_request_hook = on_request_throttle
 >>> vManageAuth.on_request_hook = on_request_throttle
 Each unique host ip has own RateLimiter (host ip is obtained automatically from request url)
@@ -19,35 +19,37 @@ from typing import Dict, Union
 from urllib3.exceptions import LocationParseError, LocationValueError
 from urllib3.util import parse_url
 
-DEFAULT_MAX_REQUESTS_PER_MINUTE = 6000
-max_requests_per_minute_setting = DEFAULT_MAX_REQUESTS_PER_MINUTE
+DEFAULT_MAX_REQUESTS_PER_SECOND = 100  # according to:
+max_requests_per_second_setting = DEFAULT_MAX_REQUESTS_PER_SECOND
 logger = logging.getLogger(__name__)
+
+HostSpecifier = Union[IPv4Address, IPv6Address, None]
 
 
 class RateLimiter:
-    def __init__(self, max_requests_per_minute: int, host: Union[IPv4Address, IPv6Address, None]):
+    def __init__(self, max_requests_per_second: int, host: HostSpecifier):
         self.host = host
         self.tlock = threading.Lock()
         self.mplock = multiprocessing.Lock()
         self.last_request_timestamp = 0.0
-        self.max_requests_per_minute = max_requests_per_minute
+        self.max_requests_per_second = max_requests_per_second
         self.hostinfo = str(host) if host else "unknown"
 
     @property
-    def max_requests_per_minute(self):
-        return self._max_requests_per_minute
+    def max_requests_per_second(self):
+        return self._max_requests_per_second
 
-    @max_requests_per_minute.setter
-    def max_requests_per_minute(self, rpm: int):
-        self._max_requests_per_minute = rpm
-        self.min_interval = 60.0 / float(rpm)
+    @max_requests_per_second.setter
+    def max_requests_per_second(self, rps: int):
+        self._max_requests_per_second = rps
+        self.min_interval = 1.0 / float(rps)
         if self.host is None:
-            logger.info(f"Default ratelimiter set to {rpm} requests per minute")
+            logger.info(f"Default ratelimiter set to {rps} requests per second")
         else:
-            logger.info(f"Host: {self.host} limited to {rpm} requests per minute")
+            logger.info(f"Host: {self.host} limited to {rps} requests per second")
 
     def block(self, **kwargs):
-        # ensures that each call is separated with min_interval
+        # ensures that each call is separated with min_interval in seconds
         with self.tlock:
             with self.mplock:
                 elapsed = time.monotonic() - self.last_request_timestamp
@@ -58,10 +60,10 @@ class RateLimiter:
                 self.last_request_timestamp = time.monotonic()
 
 
-ratelimiters: Dict[Union[IPv4Address, IPv6Address, None], RateLimiter] = {}
+ratelimiters: Dict[HostSpecifier, RateLimiter] = {}
 
 
-def url_to_host(url: Union[str, bytes]) -> Union[IPv4Address, IPv6Address, None]:
+def url_to_host(url: Union[str, bytes]) -> HostSpecifier:
     """
     Takes url like "https://tenant1.domain.com:3333/dataservice/foo"
     Return primary host IP responding to the given url, returns None when host ip cannot be determined
@@ -79,23 +81,23 @@ def url_to_host(url: Union[str, bytes]) -> Union[IPv4Address, IPv6Address, None]
         return None
 
 
-def ratelimit(max_requests_per_minute: int, host: Union[IPv4Address, IPv6Address, None] = None):
+def ratelimit(max_requests_per_second: int, host: HostSpecifier = None):
     """
     Sets or changes ratelimit for given IP host
     If host not provided it changes default ratelimit setting for new ratelimiters
     RateLimiters are also created automatically by throttle function
     """
     global ratelimiters
-    global max_requests_per_minute_setting
+    global max_requests_per_second_setting
     if host is None:
-        max_requests_per_minute_setting = max_requests_per_minute
+        max_requests_per_second_setting = max_requests_per_second
     if not ratelimiters.get(host):
-        ratelimiters[host] = RateLimiter(max_requests_per_minute, host)
+        ratelimiters[host] = RateLimiter(max_requests_per_second, host)
     else:
-        ratelimiters[host].max_requests_per_minute = max_requests_per_minute
+        ratelimiters[host].max_requests_per_second = max_requests_per_second
 
 
-def throttle(host: Union[IPv4Address, IPv6Address, None], **kwargs):
+def throttle(host: HostSpecifier, **kwargs):
     """
     Ensures that each call is separated with min_interval for given Host
     Creates new Ratelimiter for given host if it does not exist
@@ -103,7 +105,7 @@ def throttle(host: Union[IPv4Address, IPv6Address, None], **kwargs):
     """
     global ratelimiters
     if not ratelimiters.get(host):
-        ratelimiters[host] = RateLimiter(max_requests_per_minute_setting, host)
+        ratelimiters[host] = RateLimiter(max_requests_per_second_setting, host)
     ratelimiters[host].block(**kwargs)
 
 

--- a/vmngclient/utils/ratelimit.py
+++ b/vmngclient/utils/ratelimit.py
@@ -19,7 +19,7 @@ from typing import Dict, Union
 from urllib3.exceptions import LocationParseError, LocationValueError
 from urllib3.util import parse_url
 
-DEFAULT_MAX_REQUESTS_PER_MINUTE = 1000
+DEFAULT_MAX_REQUESTS_PER_MINUTE = 6000
 max_requests_per_minute_setting = DEFAULT_MAX_REQUESTS_PER_MINUTE
 logger = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ def ratelimit(max_requests_per_minute: int, host: Union[IPv4Address, IPv6Address
     """
     Sets or changes ratelimit for given IP host
     If host not provided it changes default ratelimit setting for new ratelimiters
-    (ratelimiters can be created automatically on traffic by throttle function)
+    RateLimiters are also created automatically by throttle function
     """
     global ratelimiters
     global max_requests_per_minute_setting

--- a/vmngclient/utils/ratelimit.py
+++ b/vmngclient/utils/ratelimit.py
@@ -1,30 +1,37 @@
 """
-This is utility module which can be help to limit requests rate globally (from multiple sessions, threads and processes)
+This is utility module which can be used to limit requests rate globally (from multiple sessions, threads and processes)
 To enable ratelimiting for all requests sent from vmanage-client in your application:
 >>> from vmngclient.utils.ratelimit import ratelimit, on_request_throttle
->>> ratelimit(100)
+>>> ratelimit(max_requests_per_minute=100)
 >>> vManageSession.on_request_hook = on_request_throttle
 >>> vManageAuth.on_request_hook = on_request_throttle
+Each unique host ip has own RateLimiter (host ip is obtained automatically from request url)
 """
 
+import logging
 import multiprocessing
 import threading
 import time
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from socket import getaddrinfo
+from socket import gaierror, gethostbyaddr
 from typing import Dict, Union
-from urllib.parse import urlparse
+
+from urllib3.exceptions import LocationParseError, LocationValueError
+from urllib3.util import parse_url
 
 DEFAULT_MAX_REQUESTS_PER_MINUTE = 1000
 max_requests_per_minute_setting = DEFAULT_MAX_REQUESTS_PER_MINUTE
+logger = logging.getLogger(__name__)
 
 
 class RateLimiter:
-    def __init__(self, max_requests_per_minute: int):
+    def __init__(self, max_requests_per_minute: int, host: Union[IPv4Address, IPv6Address, None]):
+        self.host = host
         self.tlock = threading.Lock()
         self.mplock = multiprocessing.Lock()
         self.last_request_timestamp = 0.0
         self.max_requests_per_minute = max_requests_per_minute
+        self.hostinfo = str(host) if host else "unknown"
 
     @property
     def max_requests_per_minute(self):
@@ -34,8 +41,12 @@ class RateLimiter:
     def max_requests_per_minute(self, rpm: int):
         self._max_requests_per_minute = rpm
         self.min_interval = 60.0 / float(rpm)
+        if self.host is None:
+            logger.info(f"Default ratelimiter set to {rpm} requests per minute")
+        else:
+            logger.info(f"Host: {self.host} limited to {rpm} requests per minute")
 
-    def block(self):
+    def block(self, **kwargs):
         # ensures that each call is separated with min_interval
         with self.tlock:
             with self.mplock:
@@ -43,20 +54,28 @@ class RateLimiter:
                 left_to_wait = self.min_interval - elapsed
                 if left_to_wait > 0:
                     time.sleep(left_to_wait)
+                    logger.debug(f"Delayed request to host: {self.hostinfo} {kwargs} by: {left_to_wait:.2f}s")
                 self.last_request_timestamp = time.monotonic()
 
 
 ratelimiters: Dict[Union[IPv4Address, IPv6Address, None], RateLimiter] = {}
 
 
-def url_to_host(url: str) -> Union[IPv4Address, IPv6Address, None]:
+def url_to_host(url: Union[str, bytes]) -> Union[IPv4Address, IPv6Address, None]:
     """
-    Takes url like "http://apple.fruits.com:3333/dataservice/foo"
-    And returns host IP Address
+    Takes url like "https://tenant1.domain.com:3333/dataservice/foo"
+    Return primary host IP responding to the given url, returns None when host ip cannot be determined
     """
-    host, _, port = urlparse(url).netloc.partition(":")
-    addrinfos = getaddrinfo(host, port)
-    return ip_address(addrinfos[0][4][0])
+    if isinstance(url, bytes):
+        _url = url.decode()
+    else:
+        _url = url
+    try:
+        adressess = gethostbyaddr(str(parse_url(_url).host))[2]
+        return ip_address(adressess[0])
+    except (LocationValueError, LocationParseError, gaierror):
+        logger.warning(f"Cannot obtain host ip from url: {_url}")
+        return None
 
 
 def ratelimit(max_requests_per_minute: int, host: Union[IPv4Address, IPv6Address, None] = None):
@@ -67,27 +86,27 @@ def ratelimit(max_requests_per_minute: int, host: Union[IPv4Address, IPv6Address
     """
     global ratelimiters
     global max_requests_per_minute_setting
-    if not host:
+    if host is None:
         max_requests_per_minute_setting = max_requests_per_minute
     if not ratelimiters.get(host):
-        ratelimiters[host] = RateLimiter(max_requests_per_minute)
+        ratelimiters[host] = RateLimiter(max_requests_per_minute, host)
     else:
         ratelimiters[host].max_requests_per_minute = max_requests_per_minute
 
 
-def throttle(host: Union[IPv4Address, IPv6Address, None] = None):
+def throttle(host: Union[IPv4Address, IPv6Address, None], **kwargs):
     """
     Ensures that each call is separated with min_interval for given Host
     One ratelimiter is shared for all throttle calls when host is not provided
     """
     global ratelimiters
     if not ratelimiters.get(host):
-        ratelimiters[host] = RateLimiter(max_requests_per_minute_setting)
-    ratelimiters[host].block()
+        ratelimiters[host] = RateLimiter(max_requests_per_minute_setting, host)
+    ratelimiters[host].block(**kwargs)
 
 
-def on_request_throttle(method: str, url: str, *args, **kwargs):
+def on_request_throttle(method: str, url: Union[bytes, str], *args, **kwargs):
     """
     Example of function performing throttle with matching signature of vmngclient.session.OnRequestHook
     """
-    throttle(url_to_host(url))
+    throttle(url_to_host(url), url=url)

--- a/vmngclient/utils/ratelimit.py
+++ b/vmngclient/utils/ratelimit.py
@@ -5,42 +5,59 @@ To enable ratelimiting for all requests sent from vmanage-client in your applica
 >>> ratelimit(max_requests_per_second=100)
 >>> vManageSession.on_request_hook = on_request_throttle
 >>> vManageAuth.on_request_hook = on_request_throttle
-Each unique host ip has own RateLimiter (host ip is obtained automatically from request url)
+Each unique host ip will have its own RateLimiter (host ip is obtained automatically from request url)
+
+According to SD-WAN documentation responses are being rate-limited:
+https://developer.cisco.com/docs/sdwan/#!browsing-returned-results-sorting-results-filtering-results-and-rate-limits/rate-limits-on-results
+https://developer.cisco.com/docs/sdwan/#!bulk-api
+This does not mean that rate-limiting in client is required,
+but application can benefit from increased stability when implemented (not overloading vManage)
 """
 
 import logging
-import multiprocessing
-import threading
+import pickle
 import time
 from ipaddress import IPv4Address, IPv6Address, ip_address
+from math import ceil
+from multiprocessing import current_process
+from multiprocessing.shared_memory import SharedMemory
+from pathlib import Path
 from socket import gaierror, gethostbyaddr, herror
 from typing import Dict, Union
 
+from oslo_concurrency import lockutils
 from urllib3.exceptions import LocationParseError, LocationValueError
 from urllib3.util import parse_url
 
-DEFAULT_MAX_REQUESTS_PER_SECOND = 100  # according to:
-max_requests_per_second_setting = DEFAULT_MAX_REQUESTS_PER_SECOND
-logger = logging.getLogger(__name__)
+SHARED_MEM_DSIZE = 2**16
+SHARED_MEM_DBLEN = ceil(SHARED_MEM_DSIZE.bit_length() / 8.0)
+SHARED_MEM_BUFLEN = SHARED_MEM_DSIZE + SHARED_MEM_DBLEN
+DEFAULT_MAX_REQUESTS_PER_SECOND = 100.0
+DEFAULT_BULK_MAX_REQUESTS_PER_SECOND = 0.8
 
+logger = logging.getLogger(__name__)
+synchronized = lockutils.synchronized_with_prefix(__package__)
+lockutils.set_defaults(str(Path.home() / __package__))
 HostSpecifier = Union[IPv4Address, IPv6Address, None]
 
 
 class RateLimiter:
-    def __init__(self, max_requests_per_second: int, host: HostSpecifier):
+    def __init__(self, max_requests_per_second: float, host: HostSpecifier):
         self.host = host
-        self.tlock = threading.Lock()
-        self.mplock = multiprocessing.Lock()
         self.last_request_timestamp = 0.0
         self.max_requests_per_second = max_requests_per_second
         self.hostinfo = str(host) if host else "unknown"
+
+    @property
+    def lock(self):
+        return lockutils.external_lock(name=self.hostinfo, lock_file_prefix=__package__)
 
     @property
     def max_requests_per_second(self):
         return self._max_requests_per_second
 
     @max_requests_per_second.setter
-    def max_requests_per_second(self, rps: int):
+    def max_requests_per_second(self, rps: float):
         self._max_requests_per_second = rps
         self.min_interval = 1.0 / float(rps)
         if self.host is None:
@@ -50,17 +67,72 @@ class RateLimiter:
 
     def block(self, **kwargs):
         # ensures that each call is separated with min_interval in seconds
-        with self.tlock:
-            with self.mplock:
-                elapsed = time.monotonic() - self.last_request_timestamp
-                left_to_wait = self.min_interval - elapsed
-                if left_to_wait > 0:
-                    time.sleep(left_to_wait)
-                    logger.debug(f"Delayed request to host: {self.hostinfo} {kwargs} by: {left_to_wait:.2f}s")
-                self.last_request_timestamp = time.monotonic()
+        elapsed = time.monotonic() - self.last_request_timestamp
+        left_to_wait = self.min_interval - elapsed
+        if left_to_wait > 0:
+            time.sleep(left_to_wait)
+            # logger.debug(f"Delayed request to host: {self.hostinfo} {kwargs} by: {left_to_wait:.2f}s")
+            logger.debug(f"Delayed request to host: {self.hostinfo} {kwargs} by: {left_to_wait:.2f}s")
+        self.last_request_timestamp = time.monotonic()
+        # logger.info(f"{self} timestamp: {self.last_request_timestamp}")
 
 
-ratelimiters: Dict[HostSpecifier, RateLimiter] = {}
+class RateLimiters:
+    def __init__(self, default_requests_per_second: int):
+        self.default_rps = default_requests_per_second
+        self.dict: Dict[HostSpecifier, RateLimiter] = {}
+
+    def __getitem__(self, host: HostSpecifier) -> RateLimiter:
+        return self.dict[host]
+
+    def __setitem__(self, host: HostSpecifier, ratelimiter: RateLimiter):
+        self.dict[host] = ratelimiter
+
+    def ratelimit(self, max_requests_per_second: int, host: HostSpecifier = None):
+        if host is None:
+            self.default_rps = max_requests_per_second
+        if ratelimiter := self.dict.get(host):
+            ratelimiter.max_requests_per_second = max_requests_per_second
+        else:
+            self.dict[host] = RateLimiter(max_requests_per_second, host)
+
+
+@synchronized("data", external=True)
+def _store_ratelimit_data(ratelimiters: RateLimiters, create: bool = False) -> bool:
+    data = pickle.dumps(ratelimiters)
+    dlen = len(data)
+    if dlen >= SHARED_MEM_DSIZE:
+        logger.error(
+            f"Cannot create shared memory object, ratelimiters object grown too big: {dlen} > {SHARED_MEM_DSIZE}"
+        )
+        return False
+    if create:
+        try:
+            shmem = SharedMemory(name="ratelimiters")
+            shmem.close()
+            shmem.unlink()
+        except FileNotFoundError:
+            pass
+        shmem = SharedMemory(name="ratelimiters", create=True, size=SHARED_MEM_BUFLEN)
+    else:
+        shmem = SharedMemory(name="ratelimiters")
+    shmem.buf[0:SHARED_MEM_DBLEN] = len(data).to_bytes(SHARED_MEM_DBLEN, "big")
+    shmem.buf[SHARED_MEM_DBLEN : SHARED_MEM_DBLEN + dlen] = data
+    # logger.debug(f"stored to shared memory: {ratelimiters.dict}")
+    logger.info(f"stored to shared memory: {ratelimiters.dict.keys()}")
+    shmem.close()
+    return True
+
+
+@synchronized("data", external=True)
+def _load_ratelimit_data() -> RateLimiters:
+    shmem = SharedMemory(name="ratelimiters")
+    dlen = int.from_bytes(shmem.buf[0:SHARED_MEM_DBLEN], "big")
+    ratelimiters: RateLimiters = pickle.loads(shmem.buf[SHARED_MEM_DBLEN : SHARED_MEM_DBLEN + dlen])
+    # logger.debug(f"read from shared memory: {ratelimiters.dict}")
+    logger.info(f"loaded from shared memory: {ratelimiters.dict.keys()}")
+    shmem.close()
+    return ratelimiters
 
 
 def url_to_host(url: Union[str, bytes]) -> HostSpecifier:
@@ -83,18 +155,27 @@ def url_to_host(url: Union[str, bytes]) -> HostSpecifier:
 
 def ratelimit(max_requests_per_second: int, host: HostSpecifier = None):
     """
-    Sets or changes ratelimit for given IP host
-    If host not provided it changes default ratelimit setting for new ratelimiters
+    Sets or changes ratelimit for given host IP
+    If host not provided it changes default ratelimit setting for all new ratelimiters
     RateLimiters are also created automatically by throttle function
     """
-    global ratelimiters
-    global max_requests_per_second_setting
-    if host is None:
-        max_requests_per_second_setting = max_requests_per_second
-    if not ratelimiters.get(host):
-        ratelimiters[host] = RateLimiter(max_requests_per_second, host)
-    else:
-        ratelimiters[host].max_requests_per_second = max_requests_per_second
+    ratelimiters = _load_ratelimit_data()
+    ratelimiters.ratelimit(max_requests_per_second, host)
+    _store_ratelimit_data(ratelimiters)
+
+    # global ratelimiters
+    # global max_requests_per_second_setting
+    # if host is None:
+    #     max_requests_per_second_setting = max_requests_per_second
+    # if not ratelimiters.get(host):
+    #     ratelimiters[host] = RateLimiter(max_requests_per_second, host)
+    # else:
+    #     ratelimiters[host].max_requests_per_second = max_requests_per_second
+
+
+def clear():
+    # clears/initializes ratelimiters to defaults
+    _store_ratelimit_data(ratelimiters=RateLimiters(DEFAULT_MAX_REQUESTS_PER_SECOND), create=True)
 
 
 def throttle(host: HostSpecifier, **kwargs):
@@ -103,10 +184,19 @@ def throttle(host: HostSpecifier, **kwargs):
     Creates new Ratelimiter for given host if it does not exist
     One shared RateLimiter is used for all throttle calls for which host ip cannot be determined from url
     """
-    global ratelimiters
-    if not ratelimiters.get(host):
-        ratelimiters[host] = RateLimiter(max_requests_per_second_setting, host)
-    ratelimiters[host].block(**kwargs)
+    ratelimiters = _load_ratelimit_data()
+    if not ratelimiters.dict.get(host):
+        ratelimiters[host] = RateLimiter(ratelimiters.default_rps, host)
+    ratelimiter = ratelimiters[host]
+    ratelimiter.lock.acquire()
+    ratelimiter.block(**kwargs)
+    _store_ratelimit_data(ratelimiters)
+    ratelimiter.lock.release()
+
+    # global ratelimiters
+    # if not ratelimiters.get(host):
+    #     ratelimiters[host] = RateLimiter(max_requests_per_second_setting, host)
+    # ratelimiters[host].block(**kwargs)
 
 
 def on_request_throttle(method: str, url: Union[bytes, str], *args, **kwargs):
@@ -114,3 +204,7 @@ def on_request_throttle(method: str, url: Union[bytes, str], *args, **kwargs):
     Example of function performing throttle with matching signature of vmngclient.session.OnRequestHook
     """
     throttle(url_to_host(url), url=url)
+
+
+if current_process().name == "MainProcess":
+    clear()


### PR DESCRIPTION
Created `on_request_hook` for `vManageSession` and `vManageAuth` which allows to attach custom user function which will be executed right before request is sent to vmanage.
Hooks can be assigned to a class (will attach to every new instance) or can be assigned after instance is created.
Added `ratelimit` utility module which demonstrates how global ratelimiting using `on_request_hook` can be implemented:
```python
from vmngclient.utils.ratelimit import ratelimit, on_request_throttle
ratelimit(max_requests_per_minute=100)
vManageSession.on_request_hook = on_request_throttle
vManageAuth.on_request_hook = on_request_throttle
```