### PR TITLE
logging-improvements

### DIFF
--- a/vmngclient/logging.conf
+++ b/vmngclient/logging.conf
@@ -30,7 +30,7 @@ formatter=simpleFormatter
 args=('vmngclient.log', 'w')
 
 [formatter_simpleFormatter]
-format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+format=%(asctime)s - %(name)s - %(levelname)s - %(threadName)s - %(message)s
 datefmt=%Y-%m-%d %H:%M:%S
 
 [formatter_consoleFormatter]

--- a/vmngclient/response.py
+++ b/vmngclient/response.py
@@ -71,6 +71,7 @@ def response_debug(response: Optional[Response], request: Union[Request, Prepare
         response_debug = {
             "status": response.status_code,
             "reason": response.reason,
+            "elapsed-seconds": float(response.elapsed.microseconds) / 1000000,
             "headers": dict(response.headers.items()),
         }
         try:

--- a/vmngclient/response.py
+++ b/vmngclient/response.py
@@ -78,10 +78,13 @@ def response_debug(response: Optional[Response], request: Union[Request, Prepare
             json.pop("header", None)
             response_debug.update({"json": json})
         except JSONDecodeError:
-            if len(response.text) <= 1024:
-                response_debug.update({"text": response.text})
+            if response.encoding is not None:
+                if len(response.text) <= 1024:
+                    response_debug.update({"text": response.text})
+                else:
+                    response_debug.update({"text(trimmed)": response.text[:1024]})
             else:
-                response_debug.update({"text(trimmed)": response.text[:128]})
+                response_debug.update({"text": "cannot convert to string: unknown encoding"})
         debug_dict["response"] = response_debug
     return pformat(debug_dict, width=80, sort_dicts=False)
 

--- a/vmngclient/response.py
+++ b/vmngclient/response.py
@@ -53,7 +53,7 @@ def response_debug(response: Optional[Response], request: Union[Request, Prepare
         response_debug = {
             "status": response.status_code,
             "reason": response.reason,
-            "elapsed-seconds": float(response.elapsed.microseconds) / 1000000,
+            "elapsed-seconds": round(float(response.elapsed.microseconds) / 1000000, 3),
             "headers": dict(response.headers.items()),
         }
         try:

--- a/vmngclient/response.py
+++ b/vmngclient/response.py
@@ -1,14 +1,12 @@
-import multiprocessing
 from functools import wraps
 from pprint import pformat
-from traceback import extract_stack
 from typing import Any, Callable, Optional, Sequence, Type, TypeVar, Union, cast
 
 from attr import define  # type: ignore
 from requests import PreparedRequest, Request, Response
 from requests.exceptions import JSONDecodeError
 
-from vmngclient import get_first_external_stack_frame
+from vmngclient import with_proc_info_header
 from vmngclient.dataclasses import DataclassBase
 from vmngclient.typed_list import DataSequence
 from vmngclient.utils.creation_tools import create_dataclass
@@ -21,22 +19,6 @@ class ErrorInfo(DataclassBase):
     message: str
     details: str
     code: str
-
-
-def with_proc_info_header(method: Callable[..., str]) -> Callable[..., str]:
-    """
-    Adds process ID and external caller information before first line of returned string
-    """
-
-    @wraps(method)
-    def wrapper(*args, **kwargs) -> str:
-        wrapped = method(*args, **kwargs)
-        fname, line_no, function, _ = get_first_external_stack_frame(extract_stack())
-        external_caller_info = "%s:%d %s(...)" % (fname, line_no, function)
-        header = f"{multiprocessing.current_process()} {external_caller_info}\n"
-        return header + wrapped
-
-    return wrapper
 
 
 def response_debug(response: Optional[Response], request: Union[Request, PreparedRequest, None]) -> str:

--- a/vmngclient/response.py
+++ b/vmngclient/response.py
@@ -84,7 +84,7 @@ def response_debug(response: Optional[Response], request: Union[Request, Prepare
                 else:
                     response_debug.update({"text(trimmed)": response.text[:1024]})
             else:
-                response_debug.update({"text": "cannot convert to string: unknown encoding"})
+                response_debug.update({"text(cannot convert to string: unknown encoding)": None})
         debug_dict["response"] = response_debug
     return pformat(debug_dict, width=80, sort_dicts=False)
 

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -51,7 +51,7 @@ def create_vManageSession(
     password: str,
     port: Optional[int] = None,
     subdomain: Optional[str] = None,
-    logger: Optional[logging.Logger] = None
+    logger: Optional[logging.Logger] = None,
 ) -> vManageSession:
     """Factory function that creates session object based on provided arguments.
 
@@ -69,9 +69,10 @@ def create_vManageSession(
 
     """
     session = vManageSession(url=url, username=username, password=password, port=port, subdomain=subdomain)
+    session.auth = vManageAuth(session.base_url, username, password, verify=False)
     if logger:
         session.logger = logger
-    session.auth = vManageAuth(session.base_url, username, password, verify=False)
+        session.auth.logger = logger
 
     if subdomain:
         tenant_id = session.get_tenant_id()

--- a/vmngclient/tests/test_vmanage_auth.py
+++ b/vmngclient/tests/test_vmanage_auth.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import TestCase, mock
 
+from requests import Request
+
 from vmngclient.vmanage_auth import InvalidCredentialsError, vManageAuth
 
 
@@ -8,6 +10,7 @@ class MockResponse:
     def __init__(self, status_code: int, text: str):
         self._status_code = status_code
         self._text = text
+        self.request = Request()
 
     def cookies(self) -> str:  # TODO
         return "JSESSIONID=xyz"

--- a/vmngclient/vmanage_auth.py
+++ b/vmngclient/vmanage_auth.py
@@ -129,4 +129,6 @@ class vManageAuth(AuthBase):
 
     @with_proc_info_header
     def _auth_request_debug(self, response: Response) -> str:
-        return f"User: {self.username} {response.request} {response.request.url} {response}"
+        return (
+            f"Authenticating: {self.username} {response.request.method} {response.request.url} <{response.status_code}>"
+        )


### PR DESCRIPTION
# Pull Request summary:
Multiple logging improvements

# Description of changes:
1. Fix a bug when response containing unknown encoding caused logging error on Windows host
```
GET /dataservice/stream/device/capture/download/{id}

--- Logging error ---
Traceback (most recent call last):
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python310\lib\logging\__init__.py", line 1103, in emit
    stream.write(msg + self.terminator)
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\ufffd' in position 2135: character maps to <undefined>
```
2. Added `elapsed-seconds` in response trace showing response time in seconds
3. Added basic logging for `vManageAuth` requests #146 
4. When custom logger is provided to `create_vManageSession` it also replaces `vManageAuth` instance logger for given session
4. Added `threadName` in default `logger.conf`

Log after changes:
```
2023-03-15 13:24:31 - vmngclient.vmanage_auth - DEBUG - MainThread - <_MainProcess name='MainProcess' parent=None started> app.py:18 <module>(...)
Authenticating: devnetuser POST https://sandbox-sdwan-2.cisco.com/j_security_check <200>
2023-03-15 13:24:32 - vmngclient.vmanage_auth - DEBUG - MainThread - <_MainProcess name='MainProcess' parent=None started> app.py:18 <module>(...)
Authenticating: devnetuser GET https://sandbox-sdwan-2.cisco.com/dataservice/client/token <200>
2023-03-15 13:24:33 - vmngclient.session - DEBUG - MainThread - <_MainProcess name='MainProcess' parent=None started> app.py:18 <module>(...)
{'request': {'method': 'GET',
             'url': 'https://sandbox-sdwan-2.cisco.com/dataservice/client/server',
             'headers': {'User-Agent': 'python-requests/2.28.1',
                         'Accept-Encoding': 'gzip, deflate',
                         'Accept': '*/*',
                         'Connection': 'keep-alive',
                         'Cookie': 'JSESSIONID=qA25_TmQOModN4vArnI9eZBmEiFqwlFOcS223WKG.81ac6722-a226-4411-9d5d-45c0ca7d567b',
                         'x-xsrf-token': 'F28F569D912B40AA0C474245B28A33BFE31D8FF84A8D9A7612A168AA715AB3387D0B78BC7DA321CB7B502B545F681277BEDD'}},
 'response': {'status': 200,
              'reason': 'OK',
              'elapsed-seconds': 0.995,
```


# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
