### PR TITLE
Workflows only on pull request

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,8 +2,6 @@ name: Static code analyzer
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   analyze_code:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,6 @@
 name: Static code analyzer
 
 on:
-  push:
   pull_request:
     branches:
       - main

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,10 +1,7 @@
 name: Run unittests
 
 on:
-  push:
   pull_request:
-    branches:
-      - main
 
 jobs:
   unittests:


### PR DESCRIPTION
# Pull Request summary:
Running workflows only on pull request instead of push and pull request.

# Description of changes:
Delating push from triggers in workflows so the run will not be duplicated like it is now. Also changing it so jobs run on any pull request instead of only pull requests to `main` branch.

![image](https://user-images.githubusercontent.com/85410520/225538154-453dbda1-faf6-49b7-9e11-cac87c289af9.png)

Now only 3 jobs will run instead of 5.

![image](https://user-images.githubusercontent.com/85410520/225881954-48cf95cb-7d9f-405d-ab4f-35913dcb6d47.png)

---

### Continuation to PR #175 

---

# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
