### PR TITLE
Optional field flakeId in TenantInfo

### DIFF
--- a/vmngclient/dataclasses.py
+++ b/vmngclient/dataclasses.py
@@ -309,7 +309,7 @@ class TenantInfo(DataclassBase):
     organization_name: str = field(metadata={FIELD_NAME: "orgName"})
     sub_domain: str = field(metadata={FIELD_NAME: "subDomain"})
     id: str = field(metadata={FIELD_NAME: "tenantId"})
-    flake_id: int = field(metadata={FIELD_NAME: "flakeId"})
+    flake_id: Optional[int] = field(default=None, metadata={FIELD_NAME: "flakeId"})
 
 
 @define(frozen=True)


### PR DESCRIPTION
# Pull Request summary:
Difference between 20.6 and 20.9 caused problems in `TenantInfo`.

# Description of changes:
Changing `flakeId` to optional field, because in vManage 20.6 it does not appear in response.

# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
