### PR TITLE
Add first() method to DataSequence

### DIFF
--- a/vmngclient/typed_list.py
+++ b/vmngclient/typed_list.py
@@ -167,9 +167,10 @@ class DataSequence(TypedList[T], Generic[T]):
         """Returns the only element of a sequence, or a default value if the sequence is empty.
 
         ## Example:
-        >>> seq = DataSequence(User, [User(username="User1"), User(username="User2")])
+        >>> seq = DataSequence(User, [User(username="User1")])
         >>> seq.single_or_default()
         User(username='User1', password=None, group=[], locale=None, description=None, resource_group=None)
+        >>> seq = DataSequence(User, [User(username="User1"), User(username="User2")])
         >>> seq.filter(username="User1").single_or_default()
         User(username='User1', password=None, group=[], locale=None, description=None, resource_group=None)
 
@@ -208,21 +209,22 @@ class DataSequence(TypedList[T], Generic[T]):
             self._type, filter(lambda x: all(getattr(x, a) == kwargs[a] for a in annotations), self.data)
         )
 
-    def filter_not(self, **kwargs) -> DataSequence[T]:
-        """Filters a sequence of values based on attributes.
-        Works the opposite way to filter.
+    def first(self):
+        """Returns the first element of a sequence.
 
-        >>> seq = DataSequence(User, [User(username="User1"), User(username="User2")])
-        >>> seq.filter_not(username="User1")
-        DataSequence(User, [
-            User(username='User2', password=None, group=[], locale=None, description=None, resource_group=None)
-        ])
+        ## Example:
+        >>> seq = DataSequence(Device, [Device(hostname="1", ), Device(hostname="2"), Device(hostname="3")])
+        >>> seq.first()
+        User(username='User1', password=None, group=[], locale=None, description=None, resource_group=None)
+
+        Raises:
+            InvalidOperationError: Raises when there is no elements in the sequence.
 
         Returns:
-            DataSequence: Filtered DataSequence.
+            [T]: The single element of the input sequence.
         """
-        annotations = set(kwargs.keys())
 
-        return DataSequence(
-            self._type, filter(lambda x: all(getattr(x, a) != kwargs[a] for a in annotations), self.data)
-        )
+        if len(self.data) < 1:
+            raise InvalidOperationError("The input sequence contains no elements.")
+
+        return self.data[0]

--- a/vmngclient/typed_list.py
+++ b/vmngclient/typed_list.py
@@ -207,3 +207,22 @@ class DataSequence(TypedList[T], Generic[T]):
         return DataSequence(
             self._type, filter(lambda x: all(getattr(x, a) == kwargs[a] for a in annotations), self.data)
         )
+
+    def filter_not(self, **kwargs) -> DataSequence[T]:
+        """Filters a sequence of values based on attributes.
+        Works the opposite way to filter.
+
+        >>> seq = DataSequence(User, [User(username="User1"), User(username="User2")])
+        >>> seq.filter_not(username="User1")
+        DataSequence(User, [
+            User(username='User2', password=None, group=[], locale=None, description=None, resource_group=None)
+        ])
+
+        Returns:
+            DataSequence: Filtered DataSequence.
+        """
+        annotations = set(kwargs.keys())
+
+        return DataSequence(
+            self._type, filter(lambda x: all(getattr(x, a) != kwargs[a] for a in annotations), self.data)
+        )


### PR DESCRIPTION
# Pull Request summary:
Adding `first` method to `DataSequence`

# Description of changes:
`first` is used in a situation when we want to get one element of a `DataSequence` and we dont need a specific one.

Example usage:
```python
devices = session.api.devices.get().filter(personality=Personality.VMANAGE)
# devices is a DataSequence of vManages
# if you just want one of them without specifying which

vmanage = devices.first()

```

If `first` is performed on empty `DataSequence` it raises `InvalidOperationError` with message `The input sequence contains no elements.`

Also fixed example in `single_or_default`.

# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [ ] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [ ] Mentioned the issue that this PR solves (if applicable)
- [ ] Make sure you test the changes
