### PR TITLE
Remove device category from upgrades

### DIFF
--- a/vmngclient/api/api_containter.py
+++ b/vmngclient/api/api_containter.py
@@ -9,6 +9,7 @@ from vmngclient.api.dashboard_api import DashboardAPI
 from vmngclient.api.logs_api import LogsAPI
 from vmngclient.api.omp_api import OmpAPI
 from vmngclient.api.packet_capture_api import PacketCaptureAPI
+from vmngclient.api.software_action_api import SoftwareActionAPI
 from vmngclient.api.speedtest_api import SpeedtestAPI
 from vmngclient.api.template_api import TemplatesAPI
 from vmngclient.api.tenant_api import TenantsAPI
@@ -34,3 +35,4 @@ class APIContainter:
         self.templates = TemplatesAPI(session)
         self.tenant_backup = TenantBackupRestoreAPI(session)
         self.repository = RepositoryAPI(session)
+        self.software_action = SoftwareActionAPI(session)

--- a/vmngclient/api/api_containter.py
+++ b/vmngclient/api/api_containter.py
@@ -38,5 +38,5 @@ class APIContainter:
         self.tenant_backup = TenantBackupRestoreAPI(session)
         self.repository = RepositoryAPI(session)
         self.resource_pool = ResourcePoolAPI(session)
-        self.software_action = SoftwareActionAPI(session)
-        self.partition_manager = PartitionManagerAPI(session)
+        self.software = SoftwareActionAPI(session)
+        self.partition = PartitionManagerAPI(session)

--- a/vmngclient/api/api_containter.py
+++ b/vmngclient/api/api_containter.py
@@ -9,8 +9,8 @@ from vmngclient.api.dashboard_api import DashboardAPI
 from vmngclient.api.logs_api import LogsAPI
 from vmngclient.api.omp_api import OmpAPI
 from vmngclient.api.packet_capture_api import PacketCaptureAPI
-from vmngclient.api.software_action_api import SoftwareActionAPI
 from vmngclient.api.resource_pool_api import ResourcePoolAPI
+from vmngclient.api.software_action_api import SoftwareActionAPI
 from vmngclient.api.speedtest_api import SpeedtestAPI
 from vmngclient.api.template_api import TemplatesAPI
 from vmngclient.api.tenant_api import TenantsAPI
@@ -38,4 +38,3 @@ class APIContainter:
         self.repository = RepositoryAPI(session)
         self.resource_pool = ResourcePoolAPI(session)
         self.software_action = SoftwareActionAPI(session)
-

--- a/vmngclient/api/api_containter.py
+++ b/vmngclient/api/api_containter.py
@@ -9,6 +9,7 @@ from vmngclient.api.dashboard_api import DashboardAPI
 from vmngclient.api.logs_api import LogsAPI
 from vmngclient.api.omp_api import OmpAPI
 from vmngclient.api.packet_capture_api import PacketCaptureAPI
+from vmngclient.api.partition_manager_api import PartitionManagerAPI
 from vmngclient.api.resource_pool_api import ResourcePoolAPI
 from vmngclient.api.software_action_api import SoftwareActionAPI
 from vmngclient.api.speedtest_api import SpeedtestAPI
@@ -38,3 +39,4 @@ class APIContainter:
         self.repository = RepositoryAPI(session)
         self.resource_pool = ResourcePoolAPI(session)
         self.software_action = SoftwareActionAPI(session)
+        self.partition_manager = PartitionManagerAPI(session)

--- a/vmngclient/api/partition_manager_api.py
+++ b/vmngclient/api/partition_manager_api.py
@@ -7,7 +7,7 @@ from vmngclient.api.versions_utils import DeviceVersions, RemovePartitionPayload
 from vmngclient.dataclasses import Device
 from vmngclient.typed_list import DataSequence
 from vmngclient.utils.creation_tools import asdict
-from vmngclient.utils.upgrades_helper import get_install_specification
+from vmngclient.utils.upgrades_helper import get_install_specification, validate_personalities_homogeneity
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class PartitionManagerAPI:
         session = create_vManageSession(...)
 
         # Prepare devices list
-        devices = DevicesAPI(session).get()
+        devices = session.api.devices.get()
         vsmarts = devices.filter(personality=Personality.VSMART)
 
         # Set current partion as default partition
@@ -55,6 +55,7 @@ class PartitionManagerAPI:
         Returns:
             str: set partition task id
         """
+        validate_personalities_homogeneity(devices)
         if partition:
             payload_devices = self.device_version.get_device_available(partition, devices)
         else:
@@ -84,6 +85,7 @@ class PartitionManagerAPI:
         Returns:
             str: action id
         """
+        validate_personalities_homogeneity(devices)
         if partition:
             payload_devices = self.device_version.get_device_available(partition, devices)
         else:

--- a/vmngclient/api/partition_manager_api.py
+++ b/vmngclient/api/partition_manager_api.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict, List, cast
 
-from vmngclient.api.software_action_api import DeviceType
 from vmngclient.api.versions_utils import DeviceVersionPayload, DeviceVersions, RemovePartitionPayload, RepositoryAPI
 from vmngclient.typed_list import DataSequence
 from vmngclient.utils.creation_tools import asdict
+from vmngclient.utils.upgrades_helper import get_install_specification
 
 logger = logging.getLogger(__name__)
 
@@ -37,12 +37,10 @@ class PartitionManagerAPI:
 
     """
 
-    def __init__(self, session: vManageSession, device_type: DeviceType) -> None:
+    def __init__(self, session: vManageSession) -> None:
 
         self.session = session
         self.repository = RepositoryAPI(self.session)
-        self.device_versions = DeviceVersions(self.session)
-        self.device_type = device_type
 
     def set_default_partition(self, payload_devices: DataSequence[DeviceVersionPayload]) -> str:
 
@@ -50,7 +48,7 @@ class PartitionManagerAPI:
         payload = {
             "action": "defaultpartition",
             "devices": [asdict(device) for device in payload_devices],  # type: ignore
-            "deviceType": self.device_type.value,
+            "deviceType": device_type.value,
         }
         set_default = dict(self.session.post(url, json=payload).json())
         return set_default["id"]

--- a/vmngclient/api/partition_manager_api.py
+++ b/vmngclient/api/partition_manager_api.py
@@ -7,7 +7,7 @@ from vmngclient.api.versions_utils import DeviceVersions, RemovePartitionPayload
 from vmngclient.dataclasses import Device
 from vmngclient.typed_list import DataSequence
 from vmngclient.utils.creation_tools import asdict
-from vmngclient.utils.upgrades_helper import get_install_specification, validate_personalities_homogeneity
+from vmngclient.utils.upgrades_helper import get_install_specification, validate_personality_homogeneity
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class PartitionManagerAPI:
         Returns:
             str: set partition task id
         """
-        validate_personalities_homogeneity(devices)
+        validate_personality_homogeneity(devices)
         if partition:
             payload_devices = self.device_version.get_device_available(partition, devices)
         else:
@@ -85,7 +85,7 @@ class PartitionManagerAPI:
         Returns:
             str: action id
         """
-        validate_personalities_homogeneity(devices)
+        validate_personality_homogeneity(devices)
         if partition:
             payload_devices = self.device_version.get_device_available(partition, devices)
         else:

--- a/vmngclient/api/partition_manager_api.py
+++ b/vmngclient/api/partition_manager_api.py
@@ -28,10 +28,9 @@ class PartitionManagerAPI:
         devices = DevicesAPI(session).get()
         vsmarts = devices.filter(personality=Personality.VSMART)
 
-        # Set default partition
-        payload_devices = DeviceVersions(session).get_devices_current_version(vsmarts)
-        partition_manager = PartitionManagerAPI(session,DeviceType.CONTROLLERS)
-        set_partition_id = partition_manager.set_default_partition(payload_devices)
+        # Set current partion as default partition
+        partition_manager = PartitionManagerAPI(session)
+        set_partition_id = partition_manager.set_default_partition(vsmarts)
 
         # Check action status
         TaskAPI(session, software_action_id).wait_for_completed()

--- a/vmngclient/api/software_action_api.py
+++ b/vmngclient/api/software_action_api.py
@@ -9,7 +9,7 @@ from vmngclient.exceptions import VersionDeclarationError  # type: ignore
 from vmngclient.typed_list import DataSequence
 from vmngclient.utils.creation_tools import asdict
 from vmngclient.utils.personality import Personality
-from vmngclient.utils.upgrades_helper import get_install_specification
+from vmngclient.utils.upgrades_helper import get_install_specification, validate_personalities_homogeneity
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +66,7 @@ class SoftwareActionAPI:
         Returns:
             str: Activate software action id
         """
+        validate_personalities_homogeneity(devices)
         if software_image and not version_to_activate:
             version = cast(str, self.repository.get_image_version(software_image))
         elif version_to_activate and not software_image:
@@ -113,6 +114,7 @@ class SoftwareActionAPI:
         Returns:
             str: action id
         """
+        validate_personalities_homogeneity(devices)
         if software_image and not image_version:
             version = cast(str, self.repository.get_image_version(software_image))
         elif image_version and not software_image:

--- a/vmngclient/api/software_action_api.py
+++ b/vmngclient/api/software_action_api.py
@@ -33,8 +33,8 @@ class SoftwareActionAPI:
     software_image = "viptela-20.7.2-x86_64.tar.gz"
 
     # Upgrade
-    upgrade_id = SoftwareActionAPI(session).upgrade_software(devices = vmanages,
-     software_image=software_image)
+    upgrade_id = SoftwareActionAPI(session).install(devices = vmanages,
+    software_image=software_image)
 
     # Check upgrade status
     TaskAPI(session, software_action_id).wait_for_completed()

--- a/vmngclient/api/software_action_api.py
+++ b/vmngclient/api/software_action_api.py
@@ -46,7 +46,7 @@ class SoftwareActionAPI:
         self.repository = RepositoryAPI(self.session)
         self.device_versions = DeviceVersions(self.session)
 
-    def activate_software(
+    def activate(
         self,
         devices: DataSequence[Device],
         version_to_activate: Optional[str] = "",
@@ -84,7 +84,7 @@ class SoftwareActionAPI:
         activate = dict(self.session.post(url, json=payload).json())
         return activate["id"]
 
-    def upgrade_software(
+    def install(
         self,
         devices: DataSequence[Device],
         reboot: bool = False,

--- a/vmngclient/api/software_action_api.py
+++ b/vmngclient/api/software_action_api.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 import logging
-from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
-
-from attr import define  # type: ignore
 
 from vmngclient.api.versions_utils import DeviceVersions, RepositoryAPI
 from vmngclient.dataclasses import Device
@@ -12,7 +9,7 @@ from vmngclient.exceptions import VersionDeclarationError  # type: ignore
 from vmngclient.typed_list import DataSequence
 from vmngclient.utils.creation_tools import asdict
 from vmngclient.utils.personality import Personality
-from utils.upgrades_helper import get_install_specification
+from vmngclient.utils.upgrades_helper import get_install_specification
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +72,7 @@ class SoftwareActionAPI:
             version = cast(str, version_to_activate)
         else:
             raise VersionDeclarationError("You can not provide software_image and image version at the same time!")
-        
+
         url = "/dataservice/device/action/changepartition"
         payload = {
             "action": "changepartition",
@@ -142,7 +139,10 @@ class SoftwareActionAPI:
             ],  # type: ignore
             "deviceType": install_specification.device_type.value,
         }
-        if devices.first().personality in (Personality.VMANAGE, Personality.EDGE):  # block downgrade for edges and vmanages
+        if devices.first().personality in (
+            Personality.VMANAGE,
+            Personality.EDGE,
+        ):  # block downgrade for edges and vmanages
             self._downgrade_check(payload["devices"], payload["input"]["version"], install_specification.family.value)
         upgrade = dict(self.session.post(url, json=payload).json())
         return upgrade["id"]

--- a/vmngclient/api/software_action_api.py
+++ b/vmngclient/api/software_action_api.py
@@ -9,7 +9,7 @@ from vmngclient.exceptions import VersionDeclarationError  # type: ignore
 from vmngclient.typed_list import DataSequence
 from vmngclient.utils.creation_tools import asdict
 from vmngclient.utils.personality import Personality
-from vmngclient.utils.upgrades_helper import get_install_specification, validate_personalities_homogeneity
+from vmngclient.utils.upgrades_helper import get_install_specification, validate_personality_homogeneity
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class SoftwareActionAPI:
         Returns:
             str: Activate software action id
         """
-        validate_personalities_homogeneity(devices)
+        validate_personality_homogeneity(devices)
         if software_image and not version_to_activate:
             version = cast(str, self.repository.get_image_version(software_image))
         elif version_to_activate and not software_image:
@@ -114,7 +114,7 @@ class SoftwareActionAPI:
         Returns:
             str: action id
         """
-        validate_personalities_homogeneity(devices)
+        validate_personality_homogeneity(devices)
         if software_image and not image_version:
             version = cast(str, self.repository.get_image_version(software_image))
         elif image_version and not software_image:

--- a/vmngclient/api/software_action_api.py
+++ b/vmngclient/api/software_action_api.py
@@ -28,7 +28,7 @@ class SoftwareActionAPI:
     session = create_vManageSession(...)
 
     # Prepare devices list
-    devices = DevicesAPI(session).get()
+    devices = session.api.devices.get()
     vsmarts = devices.filter(personality=Personality.VSMART)
     software_image = "viptela-20.7.2-x86_64.tar.gz"
 

--- a/vmngclient/exceptions.py
+++ b/vmngclient/exceptions.py
@@ -59,3 +59,7 @@ class TaskNotRegisteredError(Exception):
     """Raised if task_id is generated, but it's not registere in vManage"""
 
     pass
+
+
+class MultiplePersonalityError(Exception):
+    """Raised if Device DataSequnce contains devices with multiples personalities"""

--- a/vmngclient/tests/test_partition_manager_api.py
+++ b/vmngclient/tests/test_partition_manager_api.py
@@ -2,24 +2,29 @@ import unittest
 from unittest.mock import Mock, patch
 
 from vmngclient.api.partition_manager_api import PartitionManagerAPI
-from vmngclient.api.software_action_api import DeviceType
 from vmngclient.api.versions_utils import DeviceSoftwareRepository, DeviceVersionPayload, DeviceVersions, RepositoryAPI
 from vmngclient.dataclasses import Device
+from vmngclient.typed_list import DataSequence
 
 
 class TestPartitionManagerAPI(unittest.TestCase):
     def setUp(self):
-        self.device = Device(
-            personality="vedge",
-            uuid="mock_uuid",
-            id="mock_ip",
-            hostname="mock_host",
-            reachability="reachable",
-            local_system_ip="mock_ip",
-            status="normal",
-            memUsage=1.0,
-            connected_vManages=["192.168.0.1"],
-            model="vedge-cloud",
+        self.device = DataSequence(
+            Device,
+            [
+                Device(
+                    personality="vedge",
+                    uuid="mock_uuid",
+                    id="mock_ip",
+                    hostname="mock_host",
+                    reachability="reachable",
+                    local_system_ip="mock_ip",
+                    status="normal",
+                    memUsage=1.0,
+                    connected_vManages=["192.168.0.1"],
+                    model="vedge-cloud",
+                )
+            ],
         )
         self.DeviceSoftwareRepository_obj = {
             "mock_uuid": DeviceSoftwareRepository(
@@ -32,14 +37,17 @@ class TestPartitionManagerAPI(unittest.TestCase):
         }
 
         self.mock_devices = [{"deviceId": "mock_uuid", "deviceIP": "mock_ip", "version": "ver1"}]
-        self.mock_device_version_payload = [DeviceVersionPayload("mock_uuid", "mock_ip", "ver1")]
+        self.mock_device_version_payload = DataSequence(
+            DeviceVersionPayload, [DeviceVersionPayload("mock_uuid", "mock_ip", "ver1")]
+        )
         mock_session = Mock()
         self.mock_repository_object = RepositoryAPI(mock_session)
         self.mock_device_versions = DeviceVersions(self.mock_repository_object)
-        self.mock_partition_manager_obj = PartitionManagerAPI(mock_session, DeviceType.CONTROLLER)
+        self.mock_partition_manager_obj = PartitionManagerAPI(mock_session)
 
-    @patch.object(DeviceVersions, "get_device_available")
-    def test_remove_partition_if_force_true(self, mock_get_device_list):
+    @patch("vmngclient.utils.upgrades_helper.get_install_specification")
+    @patch.object(DeviceVersions, "get_devices_available_versions")
+    def test_remove_partition_if_force_true(self, mock_get_device_list, mock_get_spec):
         # Prepare mock data
         mock_get_device_list.return_value = Mock()
         mock_devices = Mock()
@@ -49,11 +57,11 @@ class TestPartitionManagerAPI(unittest.TestCase):
         self.mock_repository_object.session.post.return_value.json.return_value = {"id": "mock_action_id"}
 
         # Assert
-        answer = self.mock_partition_manager_obj.remove_partition(self.mock_device_version_payload, True)
+        answer = self.mock_partition_manager_obj.remove_partition(self.device, force=True)
         self.assertEqual(answer, "mock_action_id")
 
     @patch.object(PartitionManagerAPI, "_check_remove_partition_possibility")
-    @patch.object(DeviceVersions, "get_device_available")
+    @patch.object(DeviceVersions, "get_devices_available_versions")
     def test_remove_partition_not_raise_error_force_false(self, mock_get_device_list, mock_check_remove):
         # Prepare mock data
         mock_get_device_list.return_value = self.mock_device_version_payload
@@ -62,7 +70,7 @@ class TestPartitionManagerAPI(unittest.TestCase):
         self.mock_repository_object.session.post.return_value.json.return_value = {"id": "mock_action_id"}
 
         # Assert
-        answer = self.mock_partition_manager_obj.remove_partition(self.mock_device_version_payload, False)
+        answer = self.mock_partition_manager_obj.remove_partition(self.device, force=False)
         self.assertEqual(answer, "mock_action_id", "action ids not equal")
 
     @patch.object(RepositoryAPI, "get_devices_versions_repository")
@@ -84,13 +92,14 @@ class TestPartitionManagerAPI(unittest.TestCase):
         answer = self.mock_partition_manager_obj._check_remove_partition_possibility(mock_devices)
         self.assertEqual(answer, None, "lists are not equal")
 
+    @patch.object(DeviceVersions, "get_devices_current_version")
     @patch("vmngclient.session.vManageSession")
-    def test_set_default_partition(self, mock_session):
+    def test_set_default_partition(self, mock_session, mock_get_devices):
         # Arrange
-        mock_partition_manager = PartitionManagerAPI(mock_session, DeviceType.CONTROLLER)
+        mock_partition_manager = PartitionManagerAPI(mock_session)
         mock_partition_manager.session.post.return_value.json.return_value = {"id": "id_1"}
         # Act
-        answer = mock_partition_manager.set_default_partition(self.mock_device_version_payload)
+        answer = mock_partition_manager.set_default_partition(self.device)
 
         # Assert
         self.assertEqual(answer, "id_1")

--- a/vmngclient/tests/test_partition_manager_api.py
+++ b/vmngclient/tests/test_partition_manager_api.py
@@ -3,13 +3,7 @@ from unittest.mock import Mock, patch
 
 from vmngclient.api.partition_manager_api import PartitionManagerAPI
 from vmngclient.api.software_action_api import DeviceType
-from vmngclient.api.versions_utils import (
-    DeviceCategory,
-    DeviceSoftwareRepository,
-    DeviceVersionPayload,
-    DeviceVersions,
-    RepositoryAPI,
-)
+from vmngclient.api.versions_utils import DeviceSoftwareRepository, DeviceVersionPayload, DeviceVersions, RepositoryAPI
 from vmngclient.dataclasses import Device
 
 
@@ -41,10 +35,8 @@ class TestPartitionManagerAPI(unittest.TestCase):
         self.mock_device_version_payload = [DeviceVersionPayload("mock_uuid", "mock_ip", "ver1")]
         mock_session = Mock()
         self.mock_repository_object = RepositoryAPI(mock_session)
-        self.mock_device_versions = DeviceVersions(self.mock_repository_object, DeviceCategory.CONTROLLERS)
-        self.mock_partition_manager_obj = PartitionManagerAPI(
-            mock_session, DeviceCategory.CONTROLLERS, DeviceType.CONTROLLER
-        )
+        self.mock_device_versions = DeviceVersions(self.mock_repository_object)
+        self.mock_partition_manager_obj = PartitionManagerAPI(mock_session, DeviceType.CONTROLLER)
 
     @patch.object(DeviceVersions, "get_device_available")
     def test_remove_partition_if_force_true(self, mock_get_device_list):
@@ -95,7 +87,7 @@ class TestPartitionManagerAPI(unittest.TestCase):
     @patch("vmngclient.session.vManageSession")
     def test_set_default_partition(self, mock_session):
         # Arrange
-        mock_partition_manager = PartitionManagerAPI(mock_session, DeviceCategory.CONTROLLERS, DeviceType.CONTROLLER)
+        mock_partition_manager = PartitionManagerAPI(mock_session, DeviceType.CONTROLLER)
         mock_partition_manager.session.post.return_value.json.return_value = {"id": "id_1"}
         # Act
         answer = mock_partition_manager.set_default_partition(self.mock_device_version_payload)

--- a/vmngclient/tests/test_software_action_api.py
+++ b/vmngclient/tests/test_software_action_api.py
@@ -1,9 +1,11 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from vmngclient.api.software_action_api import Family, InstallSpecHelper, SoftwareActionAPI
+from vmngclient.api.software_action_api import SoftwareActionAPI
 from vmngclient.api.versions_utils import DeviceSoftwareRepository, DeviceVersions, RepositoryAPI
 from vmngclient.dataclasses import Device
+from vmngclient.typed_list import DataSequence
+from vmngclient.utils.upgrades_helper import Family, InstallSpecHelper
 
 
 class TestSoftwareAcionAPI(unittest.TestCase):
@@ -51,7 +53,7 @@ class TestSoftwareAcionAPI(unittest.TestCase):
         mock_session.post.return_value = {"id": "mock_action_id"}
 
         # Assert
-        answer = self.mock_software_action_obj.upgrade_software([self.device], True, True, "path")
+        answer = self.mock_software_action_obj.install(DataSequence(Device, [self.device]), True, True, "path")
         self.assertEqual(answer, "mock_action_id", "action ids not equal")
 
     @patch.object(RepositoryAPI, "get_devices_versions_repository")

--- a/vmngclient/tests/test_software_action_api.py
+++ b/vmngclient/tests/test_software_action_api.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from vmngclient.api.software_action_api import Family, InstallSpecHelper, SoftwareActionAPI
-from vmngclient.api.versions_utils import DeviceCategory, DeviceSoftwareRepository, DeviceVersions, RepositoryAPI
+from vmngclient.api.versions_utils import DeviceSoftwareRepository, DeviceVersions, RepositoryAPI
 from vmngclient.dataclasses import Device
 
 
@@ -35,8 +35,8 @@ class TestSoftwareAcionAPI(unittest.TestCase):
 
         mock_session = Mock()
         self.mock_repository_object = RepositoryAPI(mock_session)
-        self.mock_device_versions = DeviceVersions(self.mock_repository_object, DeviceCategory.CONTROLLERS)
-        self.mock_software_action_obj = SoftwareActionAPI(mock_session, DeviceCategory.VEDGES)
+        self.mock_device_versions = DeviceVersions(self.mock_repository_object)
+        self.mock_software_action_obj = SoftwareActionAPI(mock_session)
 
     @patch("vmngclient.session.vManageSession")
     @patch.object(SoftwareActionAPI, "_downgrade_check")

--- a/vmngclient/tests/test_version_utils.py
+++ b/vmngclient/tests/test_version_utils.py
@@ -1,13 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from vmngclient.api.versions_utils import (
-    DeviceCategory,
-    DeviceSoftwareRepository,
-    DeviceVersionPayload,
-    DeviceVersions,
-    RepositoryAPI,
-)
+from vmngclient.api.versions_utils import DeviceSoftwareRepository, DeviceVersionPayload, DeviceVersions, RepositoryAPI
 from vmngclient.dataclasses import Device
 from vmngclient.typed_list import DataSequence
 
@@ -70,7 +64,7 @@ class TestRepositoryAPI(unittest.TestCase):
         mock_session.get_data.return_value = api_mock_response
         mock_repository_object = RepositoryAPI(mock_session)
 
-        answer = mock_repository_object.get_devices_versions_repository(DeviceCategory.CONTROLLERS)
+        answer = mock_repository_object.get_devices_versions_repository()
 
         self.assertEqual(
             answer["mock_uuid"],
@@ -84,7 +78,7 @@ class TestRepositoryAPI(unittest.TestCase):
         mock_get_devices_versions_repository.return_value = Mock()
         mock_session = Mock()
         mock_repository_object = RepositoryAPI(mock_session)
-        mock_device_versions = DeviceVersions(mock_repository_object, DeviceCategory.CONTROLLERS.value)
+        mock_device_versions = DeviceVersions(mock_repository_object)
         mock_get_devices_versions_repository.return_value = self.DeviceSoftwareRepository_obj
         answer = mock_device_versions.get_device_available("ver1", [self.device])
         expected_result = DataSequence(DeviceVersionPayload, [DeviceVersionPayload("mock_uuid", "mock_ip", "ver1")])
@@ -102,7 +96,7 @@ class TestRepositoryAPI(unittest.TestCase):
         mock_get_devices_versions_repository.return_value = Mock()
         mock_session = Mock()
         mock_repository_object = RepositoryAPI(mock_session)
-        mock_device_versions = DeviceVersions(mock_repository_object, DeviceCategory.CONTROLLERS.value)
+        mock_device_versions = DeviceVersions(mock_repository_object)
         mock_get_devices_versions_repository.return_value = self.DeviceSoftwareRepository_obj
         answer = mock_device_versions.get_device_list_in_installed("ver1", [self.device])
         expected_result = DataSequence(DeviceVersionPayload, [DeviceVersionPayload("mock_uuid", "mock_ip", "ver1")])
@@ -121,7 +115,7 @@ class TestRepositoryAPI(unittest.TestCase):
         mock_get_devices_versions_repository.return_value = Mock()
         mock_get_devices_versions_repository.return_value = self.DeviceSoftwareRepository_obj
         mock_repository_object = RepositoryAPI(mock_session)
-        mock_device_versions = DeviceVersions(mock_repository_object, DeviceCategory.CONTROLLERS)
+        mock_device_versions = DeviceVersions(mock_repository_object)
         # Act
         answer = mock_device_versions.get_devices_current_version([self.device])
         # Answer

--- a/vmngclient/utils/upgrades_helper.py
+++ b/vmngclient/utils/upgrades_helper.py
@@ -3,6 +3,8 @@ from enum import Enum
 from attr import define  # type: ignore
 
 from vmngclient.dataclasses import Device
+from vmngclient.exceptions import MultiplePersonalityError
+from vmngclient.typed_list import DataSequence
 from vmngclient.utils.personality import Personality
 
 
@@ -50,3 +52,11 @@ def get_install_specification(device: Device):
         Personality.EDGE: InstallSpecHelper.VEDGE.value,
     }
     return specification_container[device.personality]
+
+
+def validate_personalities_homogeneity(devices: DataSequence[Device]):
+    personalities = set([device.personality for device in devices])
+    if not len(personalities) == 1:
+        raise MultiplePersonalityError(
+            f"devices has got more than 1 personality, devices personalities: {personalities}"
+        )

--- a/vmngclient/utils/upgrades_helper.py
+++ b/vmngclient/utils/upgrades_helper.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+from attr import define  # type: ignore
+
+from vmngclient.dataclasses import Device
+from vmngclient.utils.personality import Personality
+
+
+class Family(Enum):
+    VEDGE = "vedge"
+    VMANAGE = "vmanage"
+
+
+class VersionType(Enum):
+    VMANAGE = "vmanage"
+
+
+class DeviceType(Enum):
+    CONTROLLER = "controller"
+    VEDGE = "vedge"
+    VMANAGE = "vmanage"
+
+
+@define
+class InstallSpecification:
+
+    family: Family
+    version_type: VersionType
+    device_type: DeviceType
+
+
+class InstallSpecHelper(Enum):
+
+    VMANAGE = InstallSpecification(Family.VMANAGE, VersionType.VMANAGE, DeviceType.VMANAGE)  # type: ignore
+    VSMART = InstallSpecification(Family.VEDGE, VersionType.VMANAGE, DeviceType.CONTROLLER)  # type: ignore
+    VBOND = InstallSpecification(Family.VEDGE, VersionType.VMANAGE, DeviceType.CONTROLLER)  # type: ignore
+    VEDGE = InstallSpecification(Family.VEDGE, VersionType.VMANAGE, DeviceType.VEDGE)  # type: ignore
+
+
+def get_install_specification(device: Device):
+    specification_container = {
+        Personality.VMANAGE: InstallSpecHelper.VMANAGE.value,
+        Personality.VBOND: InstallSpecHelper.VBOND.value,
+        Personality.VSMART: InstallSpecHelper.VSMART.value,
+        Personality.EDGE: InstallSpecHelper.VEDGE.value,
+    }
+    return specification_container[device.personality]

--- a/vmngclient/utils/upgrades_helper.py
+++ b/vmngclient/utils/upgrades_helper.py
@@ -54,7 +54,7 @@ def get_install_specification(device: Device):
     return specification_container[device.personality]
 
 
-def validate_personalities_homogeneity(devices: DataSequence[Device]):
+def validate_personality_homogeneity(devices: DataSequence[Device]):
     personalities = set([device.personality for device in devices])
     if not len(personalities) == 1:
         raise MultiplePersonalityError(

--- a/vmngclient/utils/upgrades_helper.py
+++ b/vmngclient/utils/upgrades_helper.py
@@ -30,6 +30,11 @@ class InstallSpecification:
 
 
 class InstallSpecHelper(Enum):
+    """
+    Container class for storage payload data for all personalities.
+    It's created, because personality is not clearly connected to Family, VersionType
+    or DeviceType
+    """
 
     VMANAGE = InstallSpecification(Family.VMANAGE, VersionType.VMANAGE, DeviceType.VMANAGE)  # type: ignore
     VSMART = InstallSpecification(Family.VEDGE, VersionType.VMANAGE, DeviceType.CONTROLLER)  # type: ignore


### PR DESCRIPTION
# Pull Request summary:
- Simplified usage of upgrades by removing DeviceCategory and DeviceType from SoftwareAction and PartitionManager
- Moved common part (InstallSpecification) of SoftwareAction and PartitionManger to utils/upgrades_helper
- Removed DeviceVersionPayload  from set/remove partitions methods. It generates automatically, user passes just DataSequence of devices. Optionally user can pass partition argument, if no - current partiton will be set as default/all available partitions will be removed
 - Add SoftwareAction to api_container
 - add validator to check if all devices have same personality

# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
