### PR TITLE
add view decorator

### DIFF
--- a/vmngclient/exceptions.py
+++ b/vmngclient/exceptions.py
@@ -54,6 +54,11 @@ class APIVersionError(Exception):
         self.message = f"vManage is running: {current} but {item} only supported in API version: {supported}"
 
 
+class APIViewError(Exception):
+    def __init__(self, item, allowed, current):
+        self.message = f"Current view is: {current} but {item} only allowed for views: {allowed}"
+
+
 class AuthenticationError(Exception):
     pass
 

--- a/vmngclient/primitives/__init__.py
+++ b/vmngclient/primitives/__init__.py
@@ -81,8 +81,8 @@ class View:
     Logs warning or raises exception when incompatibility found.
     """
 
-    def __init__(self, allowed_sessions: Set[SessionType], raises: bool = False):
-        self.allowed_sessions = allowed_sessions
+    def __init__(self, allowed_session_types: Set[SessionType], raises: bool = False):
+        self.allowed_session_types = allowed_session_types
         self.raises = raises
 
     def __call__(self, func):
@@ -91,7 +91,7 @@ class View:
             if not isinstance(api, APIPrimitiveBase):
                 raise TypeError("Only APIPrimitiveBase instance methods can be annotated with @Versions decorator")
             current = api.session_type
-            allowed = self.allowed_sessions
+            allowed = self.allowed_session_types
             if current and current not in allowed:
                 if self.raises:
                     raise APIViewError(func, allowed, current)

--- a/vmngclient/primitives/tenant_backup_restore_api.py
+++ b/vmngclient/primitives/tenant_backup_restore_api.py
@@ -1,0 +1,29 @@
+from vmngclient.primitives import APIPrimitiveBase, View
+from vmngclient.session import ProviderAsTenantView, TenantView
+
+
+class TenantBackupRestoreApi(APIPrimitiveBase):
+    @View({ProviderAsTenantView})
+    def delete_tenant_backup(self):
+        # DELETE /tenantbackup/delete
+        ...
+
+    @View({ProviderAsTenantView, TenantView})
+    def download_existing_backup_file(self):
+        # GET /tenantbackup/download/{path}
+        ...
+
+    @View({ProviderAsTenantView, TenantView})
+    def export_tenant_backup(self):
+        # GET /tenantbackup/export
+        ...
+
+    @View({ProviderAsTenantView})
+    def import_tenant_backup(self):
+        # POST /tenantbackup/import
+        ...
+
+    @View({ProviderAsTenantView, TenantView})
+    def list_tenant_backup(self):
+        # GET /tenantbackup/list
+        ...

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -30,6 +30,11 @@ class SessionType(Enum):
     NOT_DEFINED = auto()
 
 
+ProviderView = SessionType.PROVIDER
+TenantView = SessionType.TENANT
+ProviderAsTenantView = SessionType.PROVIDER_AS_TENANT
+
+
 class UserMode(Enum):
     PROVIDER = "provider"
     TENANT = "tenant"

--- a/vmngclient/tests/test_primitives.py
+++ b/vmngclient/tests/test_primitives.py
@@ -95,7 +95,7 @@ class TestAPIPrimitives(unittest.TestCase):
     )
     def test_view_decorator_passes(self, allowed_sessions, current_session):
         class ExampleAPI(APIPrimitiveBase):
-            @View(allowed_sessions=allowed_sessions, raises=True)
+            @View(allowed_session_types=allowed_sessions, raises=True)
             def versions_decorated_method(self):
                 pass
 
@@ -112,7 +112,7 @@ class TestAPIPrimitives(unittest.TestCase):
     )
     def test_view_decorator_raises(self, allowed_sessions, current_session):
         class ExampleAPI(APIPrimitiveBase):
-            @View(allowed_sessions=allowed_sessions, raises=True)
+            @View(allowed_session_types=allowed_sessions, raises=True)
             def versions_decorated_method(self):
                 pass
 
@@ -126,7 +126,7 @@ class TestAPIPrimitives(unittest.TestCase):
         current_session = ProviderView
 
         class ExampleAPI(APIPrimitiveBase):
-            @View(allowed_sessions=allowed_sessions)
+            @View(allowed_session_types=allowed_sessions)
             def versions_decorated_method(self):
                 pass
 


### PR DESCRIPTION
# Pull Request summary:
Add `@View` decorator for `APIPrimitiveBase` methods

# Description of changes:
`@View` decorator indicates intended view of given API, a runtime check is performed and warning is logged when unintended view detected. Available views are: `ProviderView`, `TenantView`, `ProviderAsTenantView`. When there are no restrictions on view for given api - decorator should not be used.
```python
from vmngclient.primitives import APIPrimitiveBase, View
from vmngclient.session import ProviderAsTenantView, TenantView


class TenantBackupRestoreApi(APIPrimitiveBase):

    @View({ProviderAsTenantView})
    def delete_tenant_backup(self):
        # DELETE /tenantbackup/delete
        ...

    @View({ProviderAsTenantView, TenantView})
    def download_existing_backup_file(self):
        # GET /tenantbackup/download/{path}
        ...

    @View({ProviderAsTenantView, TenantView})
    def export_tenant_backup(self):
        # GET /tenantbackup/export
        ...

    @View({ProviderAsTenantView})
    def import_tenant_backup(self):
        # POST /tenantbackup/import
        ...

    @View({ProviderAsTenantView, TenantView})
    def list_tenant_backup(self):
        # GET /tenantbackup/list
        ...
```

# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
