### PR TITLE
fix: get tenant id for given subdomain during session creation

### DIFF
--- a/vmngclient/exceptions.py
+++ b/vmngclient/exceptions.py
@@ -81,3 +81,13 @@ class TaskNotRegisteredError(Exception):
 
 class MultiplePersonalityError(Exception):
     """Raised if Device DataSequnce contains devices with multiples personalities"""
+
+
+class SessionNotCreatedError(Exception):
+    """Raised when vManage session cannot be created"""
+
+    pass
+
+
+class TenantSubdomainNotFound(Exception):
+    """Raised when given subdomain does not exist"""

--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -14,7 +14,13 @@ from requests.exceptions import ConnectionError, HTTPError, RequestException
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed  # type: ignore
 
 from vmngclient.api.api_containter import APIContainter
-from vmngclient.exceptions import AuthenticationError, CookieNotValidError, InvalidOperationError
+from vmngclient.exceptions import (
+    AuthenticationError,
+    CookieNotValidError,
+    InvalidOperationError,
+    SessionNotCreatedError,
+    TenantSubdomainNotFound,
+)
 from vmngclient.primitives.client_api import AboutInfo, ServerInfo
 from vmngclient.primitives.primitive_container import APIPrimitiveContainter
 from vmngclient.response import response_history_debug, vManageResponse
@@ -47,10 +53,6 @@ class ViewMode(Enum):
     TENANT = "tenant"
     NOT_RECOGNIZED = "not recognized"
     NOT_FOUND = "not found"
-
-
-class SessionNotCreatedError(Exception):
-    pass
 
 
 def create_vManageSession(
@@ -319,9 +321,11 @@ class vManageSession(vManageResponseAdapter):
         Returns:
             Tenant UUID.
         """
-        tenants = self.primitives.multitenant_apis_provider_api.get_all_tenants()
-        tenant_id = tenants.filter(sub_domain=self.subdomain).single_or_default("")
-        return tenant_id
+        tenants = self.get_data(url="/dataservice/tenant")
+        tenant_ids = [tenant.get("tenantId", None) for tenant in tenants if tenant["subDomain"] == self.subdomain]
+        if len(tenant_ids) < 1:
+            raise TenantSubdomainNotFound(f"Tenant with sub-domain: {self.subdomain} not found")
+        return tenant_ids[0]
 
     def get_virtual_session_id(self, tenant_id: str) -> str:
         """Get VSessionId for a specific tenant


### PR DESCRIPTION
# Pull Request summary:
Provide dedicated exception when trying to perform login with unknown subdomain.
Don't use API primitives as they're annotated with specific `@View` (in time of session creation, it is not yet ready for comparison)

# Description of changes:

# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
