### PR TITLE
Revoked as option field

### DIFF
--- a/vmngclient/utils/dashboard.py
+++ b/vmngclient/utils/dashboard.py
@@ -106,7 +106,7 @@ class CertificatesStatus(DataclassBase):
 
     invalid: int
     warning: int
-    revoked: int
+    revoked: Optional[int] = field(default=None)
 
 
 @define


### PR DESCRIPTION
# Pull Request summary:
In vManage 20.6 `revoked` is absent.

# Description of changes:
Changed `revoked` to option field

# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [ ] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
