### PR TITLE
[vManageAuth] enhance logging message with text

### DIFF
--- a/vmngclient/tests/test_vmanage_auth.py
+++ b/vmngclient/tests/test_vmanage_auth.py
@@ -3,7 +3,7 @@ from unittest import TestCase, mock
 
 from requests import Request
 
-from vmngclient.vmanage_auth import InvalidCredentialsError, vManageAuth
+from vmngclient.vmanage_auth import UnauthorizedAccessError, vManageAuth
 
 
 class MockResponse:
@@ -75,7 +75,7 @@ class TestvManageAuth(TestCase):
         }
         auth = vManageAuth(self.base_url, username, self.password)
         # Act
-        with self.assertRaises(InvalidCredentialsError):
+        with self.assertRaises(UnauthorizedAccessError):
             auth.get_cookie()
 
         # Assert

--- a/vmngclient/vmanage_auth.py
+++ b/vmngclient/vmanage_auth.py
@@ -11,8 +11,8 @@ from vmngclient import with_proc_info_header
 from vmngclient.exceptions import vManageClientError
 
 
-class InvalidCredentialsError(vManageClientError):
-    """Exception raised for invalid credentials.
+class UnauthorizedAccessError(vManageClientError):
+    """Exception raised for wrong username/password or when user not authorized to access vManage.
 
     Attributes:
         username (str): vManage username.
@@ -24,7 +24,7 @@ class InvalidCredentialsError(vManageClientError):
         self,
         username: str,
         password: str,
-        message: str = "Username and/or password is incorrect. Please try again!",
+        message: str = "Wrong username/password or user not authorized to access vManage. Please try again!",
     ):
         self.username = username
         self.password = password
@@ -92,7 +92,7 @@ class vManageAuth(AuthBase):
         )
         self.logger.debug(self._auth_request_debug(response, include_reponse_text=True))
         if response.text != "":
-            raise InvalidCredentialsError(self.username, self.password)
+            raise UnauthorizedAccessError(self.username, self.password)
         return response.cookies
 
     def fetch_token(self, cookies: RequestsCookieJar) -> str:
@@ -134,5 +134,5 @@ class vManageAuth(AuthBase):
             f"Authenticating: {self.username} {response.request.method} {response.request.url} <{response.status_code}>"
         )
         if include_reponse_text:
-            msg += f" response.txt: {response.text}"
+            msg += f" response.text: {response.text}"
         return msg

--- a/vmngclient/vmanage_auth.py
+++ b/vmngclient/vmanage_auth.py
@@ -133,6 +133,6 @@ class vManageAuth(AuthBase):
         msg = (
             f"Authenticating: {self.username} {response.request.method} {response.request.url} <{response.status_code}>"
         )
-        if include_reponse_text:
+        if include_reponse_text and response.text:
             msg += f" response.text: {response.text}"
         return msg

--- a/vmngclient/vmanage_auth.py
+++ b/vmngclient/vmanage_auth.py
@@ -73,7 +73,7 @@ class vManageAuth(AuthBase):
         If a user is un-authenticated, the response body contains a html login page with tag in it.
 
         Raises:
-            InvalidCredentialsError: _description_
+            UnauthorizedAccessError: _description_
 
         Returns:
             RequestsCookieJar: _description_

--- a/vmngclient/vmanage_auth.py
+++ b/vmngclient/vmanage_auth.py
@@ -90,7 +90,7 @@ class vManageAuth(AuthBase):
             verify=self.verify,
             headers=headers,
         )
-        self.logger.debug(self._auth_request_debug(response))
+        self.logger.debug(self._auth_request_debug(response, include_reponse_text=True))
         if response.text != "":
             raise InvalidCredentialsError(self.username, self.password)
         return response.cookies
@@ -129,7 +129,10 @@ class vManageAuth(AuthBase):
         return prepared_request
 
     @with_proc_info_header
-    def _auth_request_debug(self, response: Response) -> str:
-        return (
+    def _auth_request_debug(self, response: Response, include_reponse_text: bool = False) -> str:
+        msg = (
             f"Authenticating: {self.username} {response.request.method} {response.request.url} <{response.status_code}>"
         )
+        if include_reponse_text:
+            msg += f" response.txt: {response.text}"
+        return msg


### PR DESCRIPTION
# Pull Request summary:
Include more informative logging in auth sequence.
According to https://github.com/CiscoDevNet/vManage-client/issues/256

# Description of changes:
Include optional field to enable `response.text` log in auth sequence.

Change exception from `InvalidCredentialsError` to more general `UnauthorizedAccessError`.

Note: it will require work in the future if we would like to diagnose `response.text`: currently we catch situation when `response.text` is not empty, and assume that it will be `InvalidCredentialsError`:
```python
        self.logger.debug(self._auth_request_debug(response, include_reponse_text=True))
        if response.text != "":
            raise UnauthorizedAccessError(self.username, self.password)
        return response.cookies
```
but it can also mean other problems - auth successful but e.g. session broke suddenly or any other issue relate to network problems.


# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [ ] Make sure you test the changes
