### PR TITLE
tenant-management-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,44 @@ status = UsersAPI(session).delete_user(username="new_user")
 </details>
 
 <details>
+    <summary> <b>Tenant management</b> <i>(click to expand)</i></summary>
+
+```python
+api = session.api.tenant_management
+# create tenants
+tenants = [
+    Tenant(
+        name="tenant1",
+        orgName="CiscoDevNet",
+        subDomain="alpha.bravo.net",
+        desc="This is tenant for unit tests",
+        edgeConnectorEnable=True,
+        edgeConnectorSystemIp="172.16.255.81",
+        edgeConnectorTunnelInterfaceName="GigabitEthernet1",
+        wanEdgeForecast=1,
+    )
+]
+create_task = api.create(tenants)
+create_task.wait_for_completed()
+# list all tenants
+tenants_data = api.get_all()
+# pick tenant from list by name
+tenant = tenants_data.filter(name="tenant1").single_or_default()
+# get selected tenant id
+tenant_id = tenant.tenant_id
+# get vsession id of selected tenant
+vsessionid = api.vsession_id(tenant_id)
+# delete tenant by ids
+delete_task = api.delete([tenant_id])
+delete_task.wait_for_completed()
+# others
+api.get_hosting_capacity_on_vsmarts()
+api.get_statuses()
+api.get_vsmart_mapping()
+```
+</details>
+
+<details>
     <summary> <b>Tenant migration</b> <i>(click to expand)</i></summary>
 Preparation:
 

--- a/vmngclient/api/api_containter.py
+++ b/vmngclient/api/api_containter.py
@@ -15,8 +15,8 @@ from vmngclient.api.resource_pool_api import ResourcePoolAPI
 from vmngclient.api.software_action_api import SoftwareActionAPI
 from vmngclient.api.speedtest_api import SpeedtestAPI
 from vmngclient.api.template_api import TemplatesAPI
-from vmngclient.api.tenant_api import TenantsAPI
 from vmngclient.api.tenant_backup_restore_api import TenantBackupRestoreAPI
+from vmngclient.api.tenant_management_api import TenantManagementAPI
 from vmngclient.api.tenant_migration_api import TenantMigrationAPI
 from vmngclient.api.versions_utils import RepositoryAPI
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 class APIContainter:
     def __init__(self, session: vManageSession):
-        self.tenants = TenantsAPI(session)
+        self.tenant_management = TenantManagementAPI(session)
         self.admin_tech = AdminTechAPI(session)
         self.alarms = AlarmsAPI(session)
         self.dashboard = DashboardAPI(session)

--- a/vmngclient/api/tenant_management_api.py
+++ b/vmngclient/api/tenant_management_api.py
@@ -1,22 +1,27 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
 from vmngclient.api.task_status_api import Task
 from vmngclient.dataclasses import Device
 from vmngclient.model.tenant import Tenant
-
-if TYPE_CHECKING:
-    from vmngclient.session import vManageSession
-
+from vmngclient.primitives.tenant_management import (
+    TenantBulkDeleteRequest,
+    TenantManagementPrimitives,
+    TenantStatus,
+    vSmartTenantCapacity,
+    vSmartTenantMap,
+)
+from vmngclient.session import vManageSession
 from vmngclient.typed_list import DataSequence
 
 
 class TenantManagementAPI:
     def __init__(self, session: vManageSession):
         self.session = session
+        self.primitives = TenantManagementPrimitives(session)
 
-    def get_tenants(self, device_id: Optional[Device] = None) -> DataSequence[Tenant]:
+    def get_all(self, device_id: Optional[Device] = None) -> DataSequence[Tenant]:
         """Lists all the tenants on the vManage.
 
         In a multitenant vManage system, this API is only avaiable in the Provider view.
@@ -31,8 +36,24 @@ class TenantManagementAPI:
         if device_id:
             raise NotImplementedError()
 
-        return self.session.primitives.tenant_management.get_all_tenants()
+        return self.primitives.get_all_tenants()
 
-    def create_tenants(self, tenants: List[Tenant]) -> Task:
-        task_id = self.session.primitives.tenant_management.create_tenant_async_bulk(tenants).id
+    def create(self, tenants: List[Tenant]) -> Task:
+        task_id = self.primitives.create_tenant_async_bulk(tenants).id
         return Task(self.session, task_id)
+
+    def delete(self, delete_request: TenantBulkDeleteRequest) -> Task:
+        task_id = self.primitives.delete_tenant_async_bulk(delete_request).id
+        return Task(self.session, task_id)
+
+    def get_statuses(self) -> DataSequence[TenantStatus]:
+        return self.primitives.get_all_tenant_statuses()
+
+    def get_hosting_capacity_on_vsmarts(self) -> DataSequence[vSmartTenantCapacity]:
+        return self.primitives.get_tenant_hosting_capacity_on_vsmarts()
+
+    def get_vsmart_mapping(self) -> vSmartTenantMap:
+        return self.primitives.get_tenant_vsmart_mapping()
+
+    def vsession_id(self, tenant_id: str) -> str:
+        return self.primitives.vsession_id(tenant_id).vsessionid

--- a/vmngclient/api/tenant_management_api.py
+++ b/vmngclient/api/tenant_management_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from vmngclient.api.task_status_api import Task
 from vmngclient.dataclasses import Device
@@ -12,7 +12,10 @@ from vmngclient.primitives.tenant_management import (
     vSmartTenantCapacity,
     vSmartTenantMap,
 )
-from vmngclient.session import vManageSession
+
+if TYPE_CHECKING:
+    from vmngclient.session import vManageSession
+
 from vmngclient.typed_list import DataSequence
 
 
@@ -26,34 +29,70 @@ class TenantManagementAPI:
 
         In a multitenant vManage system, this API is only avaiable in the Provider view.
 
-        Args:
-            device_id: Lists all tenants associated with a vSmart.
-
         Returns:
-            DataSequence[TenantInfo]
+            DataSequence[TenantInfo]: List-like object containing tenant information
         """
-
-        if device_id:
-            raise NotImplementedError()
-
         return self.primitives.get_all_tenants()
 
     def create(self, tenants: List[Tenant]) -> Task:
+        """Creates tenants on vManage
+
+        Args:
+            tenants (List[Tenant]): List of tenants to be created
+
+        Returns:
+            Task: Object representing tenant creation process
+        """
         task_id = self.primitives.create_tenant_async_bulk(tenants).id
         return Task(self.session, task_id)
 
-    def delete(self, delete_request: TenantBulkDeleteRequest) -> Task:
+    def delete(self, tenant_id_list: List[str], password: Optional[str]) -> Task:
+        """Deletes tenants on vManage
+
+        Args:
+            tenant_ids (List[str]): Tenant IDs to be deleted
+            password (Optional[str]): Provider password if not provided current session password will be used
+
+        Returns:
+            Task: Object representing tenant deletion process
+        """
+        if password is None:
+            password = self.session.password
+        delete_request = TenantBulkDeleteRequest(tenantIdList=tenant_id_list, password=password)
         task_id = self.primitives.delete_tenant_async_bulk(delete_request).id
         return Task(self.session, task_id)
 
     def get_statuses(self) -> DataSequence[TenantStatus]:
+        """Gets tenant statuses from vManage
+
+        Returns:
+            DataSequence[TenantStatus]: List-like object containing tenants statuses
+        """
         return self.primitives.get_all_tenant_statuses()
 
     def get_hosting_capacity_on_vsmarts(self) -> DataSequence[vSmartTenantCapacity]:
+        """Gets tenant hosting capacity on vSmarts
+
+        Returns:
+            DataSequence[vSmartTenantCapacity]: List-like object containing tenant capacity information for each vSmart
+        """
         return self.primitives.get_tenant_hosting_capacity_on_vsmarts()
 
     def get_vsmart_mapping(self) -> vSmartTenantMap:
+        """Gets vSmart to tenant mapping
+
+        Returns:
+            vSmartTenantMap: Contains vSmart to tenant mapping
+        """
         return self.primitives.get_tenant_vsmart_mapping()
 
     def vsession_id(self, tenant_id: str) -> str:
+        """Gets VSessionId for given tenant
+
+        Args:
+            tenant_id (str): Tenant ID
+
+        Returns:
+            str: Contains VSessionId for given tenant
+        """
         return self.primitives.vsession_id(tenant_id).vsessionid

--- a/vmngclient/api/tenant_management_api.py
+++ b/vmngclient/api/tenant_management_api.py
@@ -22,7 +22,7 @@ from vmngclient.typed_list import DataSequence
 class TenantManagementAPI:
     def __init__(self, session: vManageSession):
         self.session = session
-        self.primitives = TenantManagementPrimitives(session)
+        self._primitives = TenantManagementPrimitives(session)
 
     def get_all(self, device_id: Optional[Device] = None) -> DataSequence[Tenant]:
         """Lists all the tenants on the vManage.
@@ -32,7 +32,7 @@ class TenantManagementAPI:
         Returns:
             DataSequence[TenantInfo]: List-like object containing tenant information
         """
-        return self.primitives.get_all_tenants()
+        return self._primitives.get_all_tenants()
 
     def create(self, tenants: List[Tenant]) -> Task:
         """Creates tenants on vManage
@@ -43,10 +43,10 @@ class TenantManagementAPI:
         Returns:
             Task: Object representing tenant creation process
         """
-        task_id = self.primitives.create_tenant_async_bulk(tenants).id
+        task_id = self._primitives.create_tenant_async_bulk(tenants).id
         return Task(self.session, task_id)
 
-    def delete(self, tenant_id_list: List[str], password: Optional[str]) -> Task:
+    def delete(self, tenant_id_list: List[str], password: Optional[str] = None) -> Task:
         """Deletes tenants on vManage
 
         Args:
@@ -59,7 +59,7 @@ class TenantManagementAPI:
         if password is None:
             password = self.session.password
         delete_request = TenantBulkDeleteRequest(tenantIdList=tenant_id_list, password=password)
-        task_id = self.primitives.delete_tenant_async_bulk(delete_request).id
+        task_id = self._primitives.delete_tenant_async_bulk(delete_request).id
         return Task(self.session, task_id)
 
     def get_statuses(self) -> DataSequence[TenantStatus]:
@@ -68,7 +68,7 @@ class TenantManagementAPI:
         Returns:
             DataSequence[TenantStatus]: List-like object containing tenants statuses
         """
-        return self.primitives.get_all_tenant_statuses()
+        return self._primitives.get_all_tenant_statuses()
 
     def get_hosting_capacity_on_vsmarts(self) -> DataSequence[vSmartTenantCapacity]:
         """Gets tenant hosting capacity on vSmarts
@@ -76,7 +76,7 @@ class TenantManagementAPI:
         Returns:
             DataSequence[vSmartTenantCapacity]: List-like object containing tenant capacity information for each vSmart
         """
-        return self.primitives.get_tenant_hosting_capacity_on_vsmarts()
+        return self._primitives.get_tenant_hosting_capacity_on_vsmarts()
 
     def get_vsmart_mapping(self) -> vSmartTenantMap:
         """Gets vSmart to tenant mapping
@@ -84,7 +84,7 @@ class TenantManagementAPI:
         Returns:
             vSmartTenantMap: Contains vSmart to tenant mapping
         """
-        return self.primitives.get_tenant_vsmart_mapping()
+        return self._primitives.get_tenant_vsmart_mapping()
 
     def vsession_id(self, tenant_id: str) -> str:
         """Gets VSessionId for given tenant
@@ -95,4 +95,4 @@ class TenantManagementAPI:
         Returns:
             str: Contains VSessionId for given tenant
         """
-        return self.primitives.vsession_id(tenant_id).vsessionid
+        return self._primitives.vsession_id(tenant_id).vsessionid

--- a/vmngclient/api/tenant_management_api.py
+++ b/vmngclient/api/tenant_management_api.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-from vmngclient.dataclasses import Device, TenantInfo, TierInfo
+from vmngclient.api.task_status_api import Task
+from vmngclient.dataclasses import Device
+from vmngclient.model.tenant import Tenant
 
 if TYPE_CHECKING:
     from vmngclient.session import vManageSession
@@ -10,11 +12,11 @@ if TYPE_CHECKING:
 from vmngclient.typed_list import DataSequence
 
 
-class TenantsAPI:
+class TenantManagementAPI:
     def __init__(self, session: vManageSession):
         self.session = session
 
-    def get_tenants(self, device_id: Optional[Device] = None) -> DataSequence[TenantInfo]:
+    def get_tenants(self, device_id: Optional[Device] = None) -> DataSequence[Tenant]:
         """Lists all the tenants on the vManage.
 
         In a multitenant vManage system, this API is only avaiable in the Provider view.
@@ -29,13 +31,8 @@ class TenantsAPI:
         if device_id:
             raise NotImplementedError()
 
-        response = self.session.get("/dataservice/tenant")
-        tenants = response.dataseq(TenantInfo)
+        return self.session.primitives.tenant_management.get_all_tenants()
 
-        return tenants
-
-    def get_tiers(self) -> DataSequence[TierInfo]:
-        response = self.session.get(url="dataservice/device/tier")
-        tiers = response.dataseq(TierInfo)
-
-        return tiers
+    def create_tenants(self, tenants: List[Tenant]) -> Task:
+        task_id = self.session.primitives.tenant_management.create_tenant_async_bulk(tenants).id
+        return Task(self.session, task_id)

--- a/vmngclient/dataclasses.py
+++ b/vmngclient/dataclasses.py
@@ -355,19 +355,6 @@ class CloudOnRampForSaasMode(DataclassBase):
 
 
 @define(frozen=True)
-class TenantInfo(DataclassBase):
-    """Endpoint(s): /dataservice/tenant"""
-
-    name: str
-    organization_name: str = field(metadata={FIELD_NAME: "orgName"})
-    sub_domain: str = field(metadata={FIELD_NAME: "subDomain"})
-    id: str = field(metadata={FIELD_NAME: "tenantId"})
-    description: Optional[str] = field(default=None, metadata={FIELD_NAME: "desc"})
-    state: Optional[str] = field(default=None)
-    flake_id: Optional[int] = field(default=None, metadata={FIELD_NAME: "flakeId"})
-
-
-@define(frozen=True)
 class TLOC:
     color: str
     encapsulation: str

--- a/vmngclient/primitives/monitoring_device_details.py
+++ b/vmngclient/primitives/monitoring_device_details.py
@@ -1,0 +1,167 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from vmngclient.primitives import APIPrimitiveBase
+
+
+class TLOC(BaseModel):
+    color: str
+    encapsulation: str
+
+
+class Tier(BaseModel):
+    """Endpoint: /dataservice/tier
+
+    Since vManage 20.12 version, object has been renamed to "Resource Profile".
+    """
+
+    name: str = Field(alias="tierName")
+    vpn: int
+    rid: int = Field(alias="@rid")
+    ipv4_route_limit_type: Optional[str] = Field(alias="ipv4RouteLimitType")
+    ipv4_route_limit_threshold: Optional[int] = Field(alias="ipv4RouteLimitThreshold")
+    ipv4_route_limit: Optional[int] = Field(alias="ipv4RouteLimit")
+    ipv6_route_limit_type: Optional[str] = Field(alias="ipv6RouteLimitType")
+    ipv6_route_limit_threshold: Optional[int] = Field(alias="ipv6RouteLimitThreshold")
+    ipv6_route_limit: Optional[int] = Field(alias="ipv6RouteLimit")
+    tlocs: List[TLOC] = Field(default=[])
+    # New in 20.12 version
+    nat_session_limit: Optional[int] = Field(alias="natSessionLimit")
+
+
+class MonitoringDeviceDetailsPrimitives(APIPrimitiveBase):
+    def add_tier(self):
+        #  POST /device/tier
+        ...
+
+    def delete_tier(self):
+        #  DELETE /device/tier/{tierName}
+        ...
+
+    def enable_sdavcon_device(self):
+        #  POST /device/enableSDAVC/{deviceIP}/{enable}
+        ...
+
+    def generate_device_state_data(self):
+        #  GET /data/device/state/{state_data_type}
+        ...
+
+    def generate_device_state_data_fields(self):
+        #  GET /data/device/state/{state_data_type}/fields
+        ...
+
+    def generate_device_state_data_with_query_string(self):
+        #  GET /data/device/state/{state_data_type}/query
+        ...
+
+    def get_all_device_status(self):
+        #  GET /device/status
+        ...
+
+    def get_device_counters(self):
+        #  GET /device/counters
+        ...
+
+    def get_device_list_as_key_value(self):
+        #  GET /device/keyvalue
+        ...
+
+    def get_device_models(self):
+        #  GET /device/models/{uuid}
+        ...
+
+    def get_device_only_status(self):
+        #  GET /device/devicestatus
+        ...
+
+    def get_device_running_config(self):
+        #  GET /device/config
+        ...
+
+    def get_device_running_config_html(self):
+        #  GET /device/config/html
+        ...
+
+    def get_device_tloc_status(self):
+        #  GET /device/tloc
+        ...
+
+    def get_device_tloc_util(self):
+        #  GET /device/tlocutil
+        ...
+
+    def get_device_tloc_util_details(self):
+        #  GET /device/tlocutil/detail
+        ...
+
+    def get_hardware_health_details(self):
+        #  GET /device/hardwarehealth/detail
+        ...
+
+    def get_hardware_health_summary(self):
+        #  GET /device/hardwarehealth/summary
+        ...
+
+    def get_stats_queues(self):
+        #  GET /device/stats
+        ...
+
+    def get_sync_queues(self):
+        #  GET /device/queues
+        ...
+
+    def get_tiers(self):
+        return self.get("/device/tier").dataseq(Tier)
+
+    def get_unconfigured(self):
+        #  GET /device/unconfigured
+        ...
+
+    def get_vmanage_system_ip(self):
+        #  GET /device/vmanage
+        ...
+
+    def get_vedge_inventory(self):
+        #  GET /device/vedgeinventory/detail
+        ...
+
+    def get_vedge_inventory_summary(self):
+        #  GET /device/vedgeinventory/summary
+        ...
+
+    def list_all_device_models(self):
+        #  GET /device/models
+        ...
+
+    def list_all_devices(self):
+        #  GET /device
+        ...
+
+    def list_all_monitor_details_devices(self):
+        #  GET /device/monitor
+        ...
+
+    def list_currently_syncing_devices(self):
+        #  GET /device/sync_status
+        ...
+
+    def list_reachable_devices(self):
+        #  GET /device/reachable
+        ...
+
+    def list_unreachable_devices(self):
+        #  GET /device/unreachable
+        ...
+
+    def remove_unreachable_device(self):
+        #  DELETE /device/unreachable/{deviceIP}
+        ...
+
+    def set_block_sync(self):
+        #  POST /device/blockSync
+        ...
+
+    def sync_all_devices_mem_db(self):
+        #  POST /device/syncall/memorydb
+        ...

--- a/vmngclient/primitives/primitive_container.py
+++ b/vmngclient/primitives/primitive_container.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from vmngclient.primitives.client import ClientPrimitives
 from vmngclient.primitives.configuration_dashboard_status import ConfigurationDashboardStatusPrimitives
+from vmngclient.primitives.monitoring_device_details import MonitoringDeviceDetailsPrimitives
 from vmngclient.primitives.tenant_backup_restore import TenantBackupRestorePrimitives
 from vmngclient.primitives.tenant_management import TenantManagementPrimitives
 from vmngclient.primitives.tenant_migration import TenantMigrationPrimitives
@@ -19,3 +20,4 @@ class APIPrimitiveContainter:
         self.tenant_backup_restore = TenantBackupRestorePrimitives(session)
         self.tenant_migration = TenantMigrationPrimitives(session)
         self.configuration_dashboard_status = ConfigurationDashboardStatusPrimitives(session)
+        self.monitoring_device_details = MonitoringDeviceDetailsPrimitives(session)

--- a/vmngclient/primitives/tenant_management.py
+++ b/vmngclient/primitives/tenant_management.py
@@ -105,8 +105,8 @@ class TenantManagementPrimitives(APIPrimitiveBase):
         ...
 
     @View({ProviderView, ProviderAsTenantView})
-    def get_all_tenant_statuses(self):
-        self.get("/tenantstatus").dataseq(TenantStatus)
+    def get_all_tenant_statuses(self) -> DataSequence[TenantStatus]:
+        return self.get("/tenantstatus").dataseq(TenantStatus)
 
     @View({ProviderView, ProviderAsTenantView})
     def get_all_tenants(self) -> DataSequence[Tenant]:
@@ -141,5 +141,5 @@ class TenantManagementPrimitives(APIPrimitiveBase):
         ...
 
     @View({ProviderView})
-    def vsession_id(self, tenant_id: str):
+    def vsession_id(self, tenant_id: str) -> vSessionId:
         return self.post(f"/tenant/{tenant_id}/vsessionid").dataobj(vSessionId, None)

--- a/vmngclient/tests/test_tenant_management_api.py
+++ b/vmngclient/tests/test_tenant_management_api.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch
+
+from vmngclient.api.task_status_api import Task
+from vmngclient.api.tenant_management_api import TenantManagementAPI
+from vmngclient.model.tenant import Tenant
+from vmngclient.primitives.tenant_management import vSmartTenantMap
+from vmngclient.typed_list import DataSequence
+
+
+class TenantManagementAPITest(unittest.TestCase):
+    @patch("vmngclient.session.vManageSession")
+    def setUp(self, session_mock):
+        self.session = session_mock
+        self.api = TenantManagementAPI(self.session)
+
+    def test_get_all(self):
+        tenants = self.api.get_all()
+        self.assertIsInstance(tenants, DataSequence)
+
+    def test_create(self):
+        tenants = [Tenant(id="1", name="Tenant 1")]
+        task = self.api.create(tenants)
+        self.assertIsInstance(task, Task)
+
+    def test_delete(self):
+        tenant_id_list = ["1"]
+        password = "password"
+        task = self.api.delete(tenant_id_list, password)
+        self.assertIsInstance(task, Task)
+
+    def test_get_statuses(self):
+        statuses = self.api.get_statuses()
+        self.assertIsInstance(statuses, DataSequence)
+
+    def test_get_hosting_capacity_on_vsmarts(self):
+        capacity = self.api.get_hosting_capacity_on_vsmarts()
+        self.assertIsInstance(capacity, DataSequence)
+
+    def test_get_vsmart_mapping(self):
+        mapping = self.api.get_vsmart_mapping()
+        self.assertIsInstance(mapping, vSmartTenantMap)
+
+    def test_vsession_id(self):
+        tenant_id = "1"
+        vsession_id = self.api.vsession_id(tenant_id)
+        self.assertIsInstance(vsession_id, str)

--- a/vmngclient/tests/test_tenant_management_api.py
+++ b/vmngclient/tests/test_tenant_management_api.py
@@ -1,10 +1,19 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from vmngclient.api.task_status_api import Task
 from vmngclient.api.tenant_management_api import TenantManagementAPI
 from vmngclient.model.tenant import Tenant
-from vmngclient.primitives.tenant_management import vSmartTenantMap
+from vmngclient.primitives.tenant_management import (
+    ControlStatus,
+    SiteHealth,
+    TenantStatus,
+    vEdgeHealth,
+    vSessionId,
+    vSmartStatus,
+    vSmartTenantCapacity,
+    vSmartTenantMap,
+)
 from vmngclient.typed_list import DataSequence
 
 
@@ -12,14 +21,40 @@ class TenantManagementAPITest(unittest.TestCase):
     @patch("vmngclient.session.vManageSession")
     def setUp(self, session_mock):
         self.session = session_mock
+        self.session.api_version = None
+        self.session.session_type = None
         self.api = TenantManagementAPI(self.session)
 
     def test_get_all(self):
-        tenants = self.api.get_all()
-        self.assertIsInstance(tenants, DataSequence)
+        expected_tenants = [
+            Tenant(
+                name="tenant1",
+                orgName="CiscoDevNet",
+                subDomain="alpha.bravo.net",
+                desc="This is tenant for unit tests",
+                edgeConnectorEnable=True,
+                edgeConnectorSystemIp="172.16.255.81",
+                edgeConnectorTunnelInterfaceName="GigabitEthernet1",
+                wanEdgeForecast=1,
+            )
+        ]
+        self.api._primitives.get_all_tenants = MagicMock(return_value=expected_tenants)
+        observed_tenants = self.api.get_all()
+        assert expected_tenants == observed_tenants
 
     def test_create(self):
-        tenants = [Tenant(id="1", name="Tenant 1")]
+        tenants = [
+            Tenant(
+                name="tenant1",
+                orgName="CiscoDevNet",
+                subDomain="alpha.bravo.net",
+                desc="This is tenant for unit tests",
+                edgeConnectorEnable=True,
+                edgeConnectorSystemIp="172.16.255.81",
+                edgeConnectorTunnelInterfaceName="GigabitEthernet1",
+                wanEdgeForecast=1,
+            )
+        ]
         task = self.api.create(tenants)
         self.assertIsInstance(task, Task)
 
@@ -29,19 +64,52 @@ class TenantManagementAPITest(unittest.TestCase):
         task = self.api.delete(tenant_id_list, password)
         self.assertIsInstance(task, Task)
 
+    def test_delete_auto_password(self):
+        tenant_id_list = ["1"]
+        self.session.password = "p4s$w0rD"
+        task = self.api.delete(tenant_id_list)
+        self.assertIsInstance(task, Task)
+
     def test_get_statuses(self):
-        statuses = self.api.get_statuses()
-        self.assertIsInstance(statuses, DataSequence)
+        tenant_status = TenantStatus(
+            tenantId="tenant2",
+            tenantName="TeanantTwo",
+            controlStatus=ControlStatus(controlUp=1, controlDown=0, partial=1),
+            siteHealth=SiteHealth(fullConnectivity=2, partialConnectivity=1, noConnectivity=0),
+            vEdgeHealth=vEdgeHealth(normal=3, warning=1, error=0),
+            vSmartStatus=vSmartStatus(up=1, down=0),
+        )
+        expected_statuses = DataSequence(TenantStatus, [tenant_status])
+        self.api._primitives.get_all_tenant_statuses = MagicMock(return_value=expected_statuses)
+        observed_statuses = self.api.get_statuses()
+        assert expected_statuses == observed_statuses
 
     def test_get_hosting_capacity_on_vsmarts(self):
-        capacity = self.api.get_hosting_capacity_on_vsmarts()
-        self.assertIsInstance(capacity, DataSequence)
+        capacity = vSmartTenantCapacity(vSmartUuid="ABCD-1234", totalTenantCapacity=12, currentTenantCount=5)
+        expected_capacities = DataSequence(vSmartTenantCapacity, [capacity])
+        self.api._primitives.get_tenant_hosting_capacity_on_vsmarts = MagicMock(return_value=expected_capacities)
+        observed_capacities = self.api.get_hosting_capacity_on_vsmarts()
+        assert expected_capacities == observed_capacities
 
     def test_get_vsmart_mapping(self):
-        mapping = self.api.get_vsmart_mapping()
-        self.assertIsInstance(mapping, vSmartTenantMap)
+        expected_mapping = vSmartTenantMap(
+            data={
+                "vsmart1": [
+                    Tenant(
+                        name="tenant1",
+                        orgName="Tenant1-organization",
+                        subDomain="tenant1.organization.org",
+                        flakeId=9987,
+                    )
+                ]
+            }
+        )
+        self.api._primitives.get_tenant_vsmart_mapping = MagicMock(return_value=expected_mapping)
+        observed_mapping = self.api.get_vsmart_mapping()
+        assert expected_mapping == observed_mapping
 
     def test_vsession_id(self):
-        tenant_id = "1"
-        vsession_id = self.api.vsession_id(tenant_id)
-        self.assertIsInstance(vsession_id, str)
+        expected_vsession_id = "567-DEF"
+        self.api._primitives.vsession_id = MagicMock(return_value=vSessionId(VSessionId=expected_vsession_id))
+        observed_vsession_id = self.api.vsession_id("1")
+        assert expected_vsession_id == observed_vsession_id

--- a/vmngclient/tests/test_tenant_migration_api.py
+++ b/vmngclient/tests/test_tenant_migration_api.py
@@ -3,8 +3,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from packaging.version import Version  # type: ignore
-
 from vmngclient.api.task_status_api import Task
 from vmngclient.api.tenant_migration_api import ImportTask, TenantMigrationAPI
 from vmngclient.model.tenant import Tenant
@@ -15,7 +13,6 @@ class TestTenantMigrationAPI(unittest.TestCase):
     @patch("vmngclient.session.vManageSession")
     def setUp(self, session_mock):
         self.session = session_mock
-        self.session.api_version = Version("20.6")
         self.api = TenantMigrationAPI(self.session)
 
     def test_export_tenant(self):


### PR DESCRIPTION
# Pull Request summary:
Introduce API methods for tenant management in `TenantManagementAPI`

- `get_all` GET /tenant
- `create` POST /tenant/bulk/async
- `delete` DELETE /tenant/bulk/async
- `get_statuses` GET /tenantstatus
- `get_hosting_capacity_on_vsmarts` GET /tenant/vsmart/capacity
- `get_vsmart_mapping` GET /tenant/vsmart
- `vsession_id` GET /tenant/{tenantId}/vsessionid

Remove `get_tiers` from `TenantManagementAPI`
`get_tiers` placed now in `MonitoringDeviceDetailsPrimitives` and existing code using this method was refactored.

# Description of changes:
Usage example:
```python
api = session.api.tenant_management
# create tenants
tenants = [
    Tenant(
        name="tenant1",
        orgName="CiscoDevNet",
        subDomain="alpha.bravo.net",
        desc="This is tenant for unit tests",
        edgeConnectorEnable=True,
        edgeConnectorSystemIp="172.16.255.81",
        edgeConnectorTunnelInterfaceName="GigabitEthernet1",
        wanEdgeForecast=1,
    )
]
create_task = api.create(tenants)
create_task.wait_for_completed()
# list all tenants
tenants_data = api.get_all()
# pick tenant from list by name
tenant = tenants_data.filter(name="tenant1").single_or_default()
# get selected tenant id
tenant_id = tenant.tenant_id
# get vsession id of selected tenant
vsessionid = api.vsession_id(tenant_id)
# delete tenant by ids
delete_task = api.delete([tenant_id])
delete_task.wait_for_completed()
# others
api.get_hosting_capacity_on_vsmarts()
api.get_statuses()
api.get_vsmart_mapping()
```
# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
