### PR TITLE
custom endpoint decorator chaining

### DIFF
--- a/vmngclient/endpoints/__init__.py
+++ b/vmngclient/endpoints/__init__.py
@@ -289,8 +289,8 @@ class versions(APIEndpointsDecorator):
         self.raises = raises
 
     def __call__(self, func):
-        _ofunc = getattr(func, "_ofunc", func)  # _ofunc is original function which was decorated as first
-        self.versions_lookup[_ofunc.__qualname__] = self.supported_versions
+        original_func = getattr(func, "_ofunc", func)  # grab original function
+        self.versions_lookup[original_func.__qualname__] = self.supported_versions
 
         def wrapper(*args, **kwargs):
             """Executes each time decorated method is called"""
@@ -306,7 +306,7 @@ class versions(APIEndpointsDecorator):
                     )
             return func(*args, **kwargs)
 
-        wrapper._ofunc = _ofunc
+        wrapper._ofunc = original_func  # provide original function to next decorator in chain
         return wrapper
 
 
@@ -323,8 +323,8 @@ class view(APIEndpointsDecorator):
         self.raises = raises
 
     def __call__(self, func):
-        _ofunc = getattr(func, "_ofunc", func)  # _ofunc is original function which was decorated as first
-        self.view_lookup[_ofunc.__qualname__] = self.allowed_session_types
+        original_func = getattr(func, "_ofunc", func)  # grab original function
+        self.view_lookup[original_func.__qualname__] = self.allowed_session_types
 
         def wrapper(*args, **kwargs):
             """Executes each time decorated method is called"""
@@ -340,7 +340,7 @@ class view(APIEndpointsDecorator):
                     )
             return func(*args, **kwargs)
 
-        wrapper._ofunc = _ofunc
+        wrapper._ofunc = original_func  # provide original function to next decorator in chain
         return wrapper
 
 
@@ -525,13 +525,13 @@ class request(APIEndpointsDecorator):
         return all_args_dict
 
     def __call__(self, func):
-        _ofunc = getattr(func, "_ofunc", func)  # _ofunc is original function which was decorated as first
-        self.sig = signature(_ofunc)
+        original_func = getattr(func, "_ofunc", func)  # grab original function
+        self.sig = signature(original_func)
         self.return_spec = self.specify_return_type()
         self.payload_spec = self.specify_payload_type()
         self.check_params()
-        self.request_lookup[_ofunc.__qualname__] = APIEndpointRequestMeta(
-            func=_ofunc,
+        self.request_lookup[original_func.__qualname__] = APIEndpointRequestMeta(
+            func=original_func,
             http_request=f"{self.http_method} {self.url}",
             payload_spec=self.payload_spec,
             return_spec=self.return_spec,
@@ -575,7 +575,7 @@ class request(APIEndpointsDecorator):
                 elif issubclass(self.return_spec.payload_type, dict):
                     return response.json()
 
-        wrapper._ofunc = _ofunc
+        wrapper._ofunc = original_func  # provide original function to next decorator in chain
         return wrapper
 
 

--- a/vmngclient/endpoints/__init__.py
+++ b/vmngclient/endpoints/__init__.py
@@ -273,12 +273,6 @@ class APIEndpointsDecorator:
             raise APIEndpointError("Only APIEndpointsDecorator instance methods can be annotated with @{cls} decorator")
         return _self
 
-    @staticmethod
-    def preserve_orig_func(wrapper, wrapped):
-        """Preserves original function which can can be used by wrappers by reading _ofunc attribute"""
-        wrapper._ofunc = getattr(wrapped, "_ofunc", wrapped)
-        return wrapper
-
 
 class versions(APIEndpointsDecorator):
     """
@@ -312,7 +306,8 @@ class versions(APIEndpointsDecorator):
                     )
             return func(*args, **kwargs)
 
-        return APIEndpointsDecorator.preserve_orig_func(wrapper, func)
+        wrapper._ofunc = _ofunc
+        return wrapper
 
 
 class view(APIEndpointsDecorator):
@@ -345,7 +340,8 @@ class view(APIEndpointsDecorator):
                     )
             return func(*args, **kwargs)
 
-        return APIEndpointsDecorator.preserve_orig_func(wrapper, func)
+        wrapper._ofunc = _ofunc
+        return wrapper
 
 
 class request(APIEndpointsDecorator):
@@ -579,7 +575,8 @@ class request(APIEndpointsDecorator):
                 elif issubclass(self.return_spec.payload_type, dict):
                     return response.json()
 
-        return APIEndpointsDecorator.preserve_orig_func(wrapper, func)
+        wrapper._ofunc = _ofunc
+        return wrapper
 
 
 class get(request):

--- a/vmngclient/tests/test_endpoints.py
+++ b/vmngclient/tests/test_endpoints.py
@@ -697,3 +697,22 @@ class TestAPIEndpoints(unittest.TestCase):
                         params=params,
                     )
                     self.session_mock.reset_mock()
+
+    def test_decorator_chaining_order(self):
+        # Expected @request can access original function signature (it will raise otherwise)
+        class TestAPIMixedOrder1(APIEndpoints):
+            @request("GET", "/v2/{category}/items")
+            @versions("<2")
+            def get_data(
+                self, payload: BaseModelExample, category: str, params: ParamsExample
+            ) -> None:  # type: ignore [empty-body]
+                ...
+
+        class TestAPIMixedOrder2(APIEndpoints):
+            @request("GET", "/v2/{category}/items")
+            @versions("<2")
+            @view({ProviderView})
+            def get_data(
+                self, payload: BaseModelExample, category: str, params: ParamsExample
+            ) -> None:  # type: ignore [empty-body]
+                ...


### PR DESCRIPTION
# Pull Request summary:
`functool.wraps` which helped to preserve context of wrapped methods has side effect of ruining some IDE hints (VS Code + pylint).
Providing type hints is very important to us and we want to support it for as much IDEs as possible.
Instead now we pass original function as additional wrapper atrribute `_ofunc` so all endpoint decorators can be chained in custom order and have access to it. It is not idiomatic but serves our purposes better (we need original function signature to generate request and qualname in all wrappers to generate documentation)

# Checklist:
- [x] Make sure to run pre-commit before commiting changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
