### PR TITLE
revert: flake8 bump

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     defaults:
       run:
         shell: sh
@@ -38,8 +38,4 @@ jobs:
       - name: Check static-typing
         run: poetry run mypy --show-error-codes --show-error-context --pretty --install-types --non-interactive vmngclient --cache-dir=.mypy_cache/
       - name: Check code style
-        run: poetry run flake8 --max-line-length 120 --inline-quotes double vmngclient 
-        if: ${{ matrix.python-version != '3.12' }}
-      - name: Check code style for Python 3.12
-        run: poetry run flake8 --max-line-length 120 --ignore=Q000,W503,W504 vmngclient
-        if: ${{ matrix.python-version == '3.12' }} 
+        run: poetry run flake8 --max-line-length 120 --inline-quotes double vmngclient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/CiscoDevNet/vManage-client"
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = "^3.8.0"
 requests = "^2.27.1"
 python-dateutil = "^2.8.2"
 attrs = "^21.4.0"
@@ -28,7 +28,7 @@ pytest-mock = "^3.7.0"
 isort = "^5.10.1"
 pre-commit = "^2.19.0"
 mypy = "^1.0.0"
-flake8 = "^6.1.0"
+flake8 = "^5.0.4"
 Sphinx = "^5.2.3"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vmngclient"
-version = "0.17.3"
+version = "0.17.4"
 description = "vManage SDK for Python"
 authors = ["kagorski <kagorski@cisco.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Pull Request summary:
revert: flake8 bump

# Description of changes:
revert: flake8 bump
because from 6.0.0 python 3.8.1 is required
disable linting job on 3.12

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
