### PR TITLE
add custom User-Agent in request headers

### DIFF
--- a/vmngclient/session.py
+++ b/vmngclient/session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from enum import Enum
+from importlib import metadata
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
 from urllib.parse import urljoin, urlparse, urlunparse
@@ -30,6 +31,7 @@ from vmngclient.version import NullVersion, parse_api_version
 from vmngclient.vmanage_auth import vManageAuth
 
 JSON = Union[Dict[str, "JSON"], List["JSON"], str, int, float, bool, None]
+USER_AGENT = f"{__package__}/{metadata.version(__package__)}"
 
 
 class vManageBadResponseError(vManageClientError):
@@ -206,6 +208,7 @@ class vManageSession(vManageResponseAdapter, APIEndpointClient):
             [Optional[Response], Union[Request, PreparedRequest, None]], str
         ] = response_history_debug
         super(vManageSession, self).__init__()
+        self.headers.update({"User-Agent": USER_AGENT})
         self.__prepare_session(verify, auth)
         self.api = APIContainer(self)
         self.endpoints = APIEndpointContainter(self)


### PR DESCRIPTION
# Pull Request summary:
Add distinguishable User-Agent in each request originating from `vmngclient.session.vManageSession`.
Replacing `python-requests/x.y.z` automatically generated by HTTP client library which we are using.

# Description of changes:
## Before:
```
{'request': {'method': 'GET',
             'url': 'https://127.0.0.1:9912/dataservice/client/server',
             'headers': {'User-Agent': 'python-requests/2.31.0',
```
## After:
```
{'request': {'method': 'GET',
             'url': 'https://127.0.0.1:9912/dataservice/client/server',
             'headers': {'User-Agent': 'vmngclient/0.21.0',
```

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
