### PR TITLE
Make device fields optional

### DIFF
--- a/vmngclient/dataclasses.py
+++ b/vmngclient/dataclasses.py
@@ -117,27 +117,26 @@ class AlarmData(DataclassBase):
         return result
 
 
-@define
-class Device(DataclassBase):
+class Device(BaseModel):
     uuid: str
-    personality: Personality = field(converter=Personality)
-    id: str = field(metadata={FIELD_NAME: "deviceId"})
-    hostname: str = field(metadata={FIELD_NAME: "host-name"})
-    reachability: Reachability = field(converter=Reachability)
-    local_system_ip: str = field(metadata={FIELD_NAME: "local-system-ip"})
-    status: Optional[str] = field(default=None)
-    memUsage: Optional[float] = field(default=None)
-    mem_state: Optional[str] = field(default=None, metadata={FIELD_NAME: "memState"})
-    cpu_state: Optional[str] = field(default=None, metadata={FIELD_NAME: "cpuState"})
-    cpu_load: Optional[float] = field(default=None, metadata={FIELD_NAME: "cpuLoad"})
-    state_description: Optional[str] = field(default=None)
-    connected_vManages: List[str] = field(factory=list, metadata={FIELD_NAME: "connectedVManages"})
-    model: Optional[str] = field(default=None, metadata={FIELD_NAME: "device-model"})
-    board_serial: Optional[str] = field(default=None, metadata={FIELD_NAME: "board-serial"})
-    vedgeCertificateState: Optional[str] = field(default=None, metadata={FIELD_NAME: "vedgeCertificateState"})  # TODO
-    chasis_number: Optional[str] = field(default=None, metadata={FIELD_NAME: "chasisNumber"})
-    site_id: Optional[str] = field(default=None, metadata={FIELD_NAME: "site-id"})
-    site_name: Optional[str] = field(default=None, metadata={FIELD_NAME: "site-name"})
+    personality: Personality
+    id: str = Field(..., alias="deviceId")
+    hostname: Optional[str] = Field(None, alias="host-name")
+    reachability: Optional[Reachability] = None
+    local_system_ip: Optional[str] = Field(None, alias="local-system-ip")
+    status: Optional[str] = None
+    memUsage: Optional[float] = None
+    mem_state: Optional[str] = Field(None, alias="memState")
+    cpu_state: Optional[str] = Field(None, alias="cpuState")
+    cpu_load: Optional[float] = Field(None, alias="cpuLoad")
+    state_description: Optional[str] = None
+    connected_vManages: List[str] = []
+    model: Optional[str] = Field(None, alias="device-model")
+    board_serial: Optional[str] = Field(None, alias="board-serial")
+    vedgeCertificateState: Optional[str] = Field(None, alias="vedgeCertificateState")  # TODO
+    chasis_number: Optional[str] = Field(None, alias="chasisNumber")
+    site_id: Optional[str] = Field(None, alias="site-id")
+    site_name: Optional[str] = Field(None, alias="site-name")
 
     @property
     def is_reachable(self) -> bool:


### PR DESCRIPTION
# Pull Request summary:
`/dataservice/system/device/vedges` does not returns all fields required for `Device `model

# Description of changes:
```
# Arrange
session = VMANAGE_MACHINE.create_session(provider_tenant=tenant)
device = session.api.devices.get().filter(uuid=software_vedge_uuid).single_or_default()
# Act
# TODO: Fix vmngclient
# decommission = DecommissionAction(session, device)
# decommission.execute()
# result = decommission.wait_for_completed()
# [FAIL] "TypeError in test case "mtt_device_life_cycle.test_decommission_software_vedge_provider_as_tenant" at subtest "decommission_software_vedge"[515]: 
# __init__() missing 3 required positional arguments: 'hostname', 'reachability', and 'local_system_ip'"
response = session.put(f"/dataservice/system/device/decommission/{device.uuid}")
if response.status_code != 200:
    return[False, f"Problem with decomission of {device.uuid} occurred"]
```

# Checklist:
- [X] Make sure to run pre-commit before committing changes
- [X] Make sure all checks have passed
- [X] PR description is clear and comprehensive
- [X] Mentioned the issue that this PR solves (if applicable)
- [X] Make sure you test the changes
